### PR TITLE
Get GC stats (finally)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ bootstrap:
 	$(MAKE) all
 	$(MAKE) compare
 
-LIBFILES=stdlib.cma std_exit.cmo *.cmi camlheader
+LIBFILES=stdlib.cma std_init.cmo std_exit.cmo *.cmi camlheader
 
 # Start up the system from the distribution compiler
 coldstart:

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -165,7 +165,7 @@ bootstrap:
 	$(MAKEREC) all
 	$(MAKEREC) compare
 
-LIBFILES=stdlib.cma std_exit.cmo *.cmi camlheader
+LIBFILES=stdlib.cma std_init.cmo std_exit.cmo *.cmi camlheader
 
 # Start up the system from the distribution compiler
 coldstart:

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -303,12 +303,14 @@ let call_linker file_list startup_file output_name =
 let link ppf objfiles output_name =
   let stdlib =
     if !Clflags.gprofile then "stdlib.p.cmxa" else "stdlib.cmxa" in
+  let stdinit =
+    if !Clflags.gprofile then "std_init.p.cmx" else "std_init.cmx" in
   let stdexit =
     if !Clflags.gprofile then "std_exit.p.cmx" else "std_exit.cmx" in
   let objfiles =
     if !Clflags.nopervasives then objfiles
     else if !Clflags.output_c_object then stdlib :: objfiles
-    else stdlib :: (objfiles @ [stdexit]) in
+    else stdlib :: stdinit :: (objfiles @ [stdexit]) in
   let units_tolink = List.fold_right scan_file objfiles [] in
   Array.iter remove_required Runtimedef.builtin_exceptions;
   begin match extract_missing_globals() with

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -537,7 +537,7 @@ let link ppf objfiles output_name =
   let objfiles =
     if !Clflags.nopervasives then objfiles
     else if !Clflags.output_c_object then "stdlib.cma" :: objfiles
-    else "stdlib.cma" :: (objfiles @ ["std_exit.cmo"]) in
+    else "stdlib.cma" :: "std_init.cmo" :: (objfiles @ ["std_exit.cmo"]) in
   let tolink = List.fold_right scan_file objfiles [] in
   Clflags.ccobjs := !Clflags.ccobjs @ !lib_ccobjs; (* put user's libs last *)
   Clflags.all_ccopts := !lib_ccopts @ !Clflags.all_ccopts;

--- a/otherlibs/threads/pervasives.ml
+++ b/otherlibs/threads/pervasives.ml
@@ -610,15 +610,11 @@ external sys_exit : int -> 'a = "caml_sys_exit"
 
 let exit_function = ref flush_all
 
-let last_exit_function = ref (fun () -> ())
-
 let at_exit f =
   let g = !exit_function in
   exit_function := (fun () -> f(); g())
 
-let do_at_exit () =
-  (!exit_function) ();
-  (!last_exit_function) ()
+let do_at_exit () = (!exit_function) ()
 
 let exit retcode =
   do_at_exit ();

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -157,6 +157,8 @@ sort.cmo : array.cmi sort.cmi
 sort.cmx : array.cmx sort.cmi
 stack.cmo : list.cmi stack.cmi
 stack.cmx : list.cmx stack.cmi
+std_init.cmo :
+std_init.cmx :
 std_exit.cmo :
 std_exit.cmx :
 stdLabels.cmo : stringLabels.cmi listLabels.cmi bytesLabels.cmi \
@@ -283,6 +285,8 @@ sort.cmo : array.cmi sort.cmi
 sort.p.cmx : array.p.cmx sort.cmi
 stack.cmo : list.cmi stack.cmi
 stack.p.cmx : list.p.cmx stack.cmi
+std_init.cmo :
+std_init.p.cmx :
 std_exit.cmo :
 std_exit.p.cmx :
 stdLabels.cmo : stringLabels.cmi listLabels.cmi bytesLabels.cmi \

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -14,18 +14,18 @@
 include Makefile.shared
 
 allopt:
-	$(MAKE) stdlib.cmxa std_exit.cmx
+	$(MAKE) stdlib.cmxa std_init.cmx std_exit.cmx
 	$(MAKE) allopt-$(PROFILING)
 
 allopt-noprof:
 
-allopt-prof: stdlib.p.cmxa std_exit.p.cmx
-	rm -f std_exit.p.cmi
+allopt-prof: stdlib.p.cmxa std_init.p.cmx std_exit.p.cmx
+	rm -f std_init.p.cmi std_exit.p.cmi
 
 installopt: installopt-default installopt-$(PROFILING)
 
 installopt-default:
-	cp stdlib.cmxa stdlib.a std_exit.o *.cmx $(INSTALL_LIBDIR)
+	cp stdlib.cmxa stdlib.a std_init.o std_exit.o *.cmx $(INSTALL_LIBDIR)
 	cd $(INSTALL_LIBDIR); $(RANLIB) stdlib.a
 
 installopt-noprof:
@@ -33,13 +33,17 @@ installopt-noprof:
 	  ln -s stdlib.cmxa $(INSTALL_LIBDIR)/stdlib.p.cmxa
 	rm -f $(INSTALL_LIBDIR)/stdlib.p.a; \
 	  ln -s stdlib.a $(INSTALL_LIBDIR)/stdlib.p.a
+	rm -f $(INSTALL_LIBDIR)/std_init.p.cmx; \
+	  ln -s std_init.cmx $(INSTALL_LIBDIR)/std_init.p.cmx
+	rm -f $(INSTALL_LIBDIR)/std_init.p.o; \
+	  ln -s std_init.o $(INSTALL_LIBDIR)/std_init.p.o
 	rm -f $(INSTALL_LIBDIR)/std_exit.p.cmx; \
 	  ln -s std_exit.cmx $(INSTALL_LIBDIR)/std_exit.p.cmx
 	rm -f $(INSTALL_LIBDIR)/std_exit.p.o; \
 	  ln -s std_exit.o $(INSTALL_LIBDIR)/std_exit.p.o
 
 installopt-prof:
-	cp stdlib.p.cmxa stdlib.p.a std_exit.p.cmx std_exit.p.o $(INSTALL_LIBDIR)
+	cp stdlib.p.cmxa stdlib.p.a std_init.p.cmx std_init.p.o std_exit.p.cmx std_exit.p.o $(INSTALL_LIBDIR)
 	cd $(INSTALL_LIBDIR); $(RANLIB) stdlib.p.a
 
 stdlib.p.cmxa: $(OBJS:.cmo=.p.cmx)

--- a/stdlib/Makefile.nt
+++ b/stdlib/Makefile.nt
@@ -13,10 +13,10 @@
 
 include Makefile.shared
 
-allopt: stdlib.cmxa std_exit.cmx
+allopt: stdlib.cmxa std_init.cmx std_exit.cmx
 
 installopt:
-	cp stdlib.cmxa stdlib.$(A) std_exit.$(O) *.cmx $(INSTALL_LIBDIR)
+	cp stdlib.cmxa stdlib.$(A) std_init.$(O) std_exit.$(O) *.cmx $(INSTALL_LIBDIR)
 
 camlheader target_camlheader camlheader_ur: headernt.c ../config/Makefile
 	$(BYTECC) $(BYTECCCOMPOPTS) -c -I../byterun \

--- a/stdlib/Makefile.shared
+++ b/stdlib/Makefile.shared
@@ -41,12 +41,12 @@ OTHERS=array.cmo list.cmo char.cmo bytes.cmo string.cmo sys.cmo \
   arrayLabels.cmo listLabels.cmo bytesLabels.cmo \
   stringLabels.cmo moreLabels.cmo stdLabels.cmo
 
-all: stdlib.cma std_exit.cmo camlheader target_camlheader camlheader_ur
+all: stdlib.cma std_init.cmo std_exit.cmo camlheader target_camlheader camlheader_ur
 
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 install: install-$(RUNTIMED)
-	cp stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml \
+	cp stdlib.cma std_init.cmo std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml \
 	  camlheader_ur \
 	  $(INSTALL_LIBDIR)
 	cp target_camlheader $(INSTALL_LIBDIR)/camlheader
@@ -88,18 +88,18 @@ clean::
 	$(CAMLOPT) $(COMPFLAGS) `./Compflags $@` -p -c -o $*.p.cmx $<
 
 # Dependencies on the compiler
-$(OBJS) std_exit.cmo: $(COMPILER)
-$(OBJS:.cmo=.cmi) std_exit.cmi: $(COMPILER)
-$(OBJS:.cmo=.cmx) std_exit.cmx: $(OPTCOMPILER)
-$(OBJS:.cmo=.p.cmx) std_exit.p.cmx: $(OPTCOMPILER)
+$(OBJS) std_init.cmo std_exit.cmo: $(COMPILER)
+$(OBJS:.cmo=.cmi) std_init.cmi std_exit.cmi: $(COMPILER)
+$(OBJS:.cmo=.cmx) std_init.cmx std_exit.cmx: $(OPTCOMPILER)
+$(OBJS:.cmo=.p.cmx) std_init.p.cmx std_exit.p.cmx: $(OPTCOMPILER)
 
 # Dependencies on Pervasives (not tracked by ocamldep)
-$(OTHERS) std_exit.cmo: pervasives.cmi
-$(OTHERS:.cmo=.cmi) std_exit.cmi: pervasives.cmi
-$(OBJS:.cmo=.cmx) std_exit.cmx: pervasives.cmi
-$(OBJS:.cmo=.p.cmx) std_exit.p.cmx: pervasives.cmi
-$(OTHERS:.cmo=.cmx) std_exit.cmx: pervasives.cmx
-$(OTHERS:.cmo=.p.cmx) std_exit.p.cmx: pervasives.cmx
+$(OTHERS) std_init.cmo std_exit.cmo: pervasives.cmi
+$(OTHERS:.cmo=.cmi) std_init.cmi std_exit.cmi: pervasives.cmi
+$(OBJS:.cmo=.cmx) std_init.cmx std_exit.cmx: pervasives.cmi
+$(OBJS:.cmo=.p.cmx) std_init.p.cmx std_exit.p.cmx: pervasives.cmi
+$(OTHERS:.cmo=.cmx) std_init.cmx std_exit.cmx: pervasives.cmx
+$(OTHERS:.cmo=.p.cmx) std_init.p.cmx std_exit.p.cmx: pervasives.cmx
 
 clean::
 	rm -f *.cm* *.$(O) *.$(A)

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -98,12 +98,3 @@ let create_alarm f =
 ;;
 
 let delete_alarm a = a := false;;
-
-let () =
-  last_exit_function := (fun () ->
-      try
-        let fn = Sys.getenv "OCAML_GC_STATS" in
-        let oc = open_out fn in
-        print_stat oc;
-        close_out oc
-      with _ -> ())

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -515,15 +515,11 @@ external sys_exit : int -> 'a = "caml_sys_exit"
 
 let exit_function = ref flush_all
 
-let last_exit_function = ref (fun () -> ())
-
 let at_exit f =
   let g = !exit_function in
   exit_function := (fun () -> f(); g())
 
-let do_at_exit () =
-  (!exit_function) ();
-  (!last_exit_function) ()
+let do_at_exit () = (!exit_function) ()
 
 let exit retcode =
   do_at_exit ();

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -1132,5 +1132,3 @@ val valid_float_lexem : string -> string
 val unsafe_really_input : in_channel -> bytes -> int -> int -> unit
 
 val do_at_exit : unit -> unit
-
-val last_exit_function : (unit -> unit) ref

--- a/stdlib/std_init.ml
+++ b/stdlib/std_init.ml
@@ -1,0 +1,25 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                OCaml                                *)
+(*                                                                     *)
+(*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         *)
+(*                                                                     *)
+(*  Copyright 1996 Institut National de Recherche en Informatique et   *)
+(*  en Automatique.  All rights reserved.  This file is distributed    *)
+(*  under the terms of the GNU Library General Public License, with    *)
+(*  the special exception on linking described in file ../LICENSE.     *)
+(*                                                                     *)
+(***********************************************************************)
+
+(* Loads after stdlib but before any user modules. This forces the loading of
+   the Gc module. *)
+
+let () =
+  at_exit (fun () ->
+      try
+        let fn = Sys.getenv "OCAML_GC_STATS" in
+        if fn <> "" then
+          let oc = open_out fn in
+          Gc.print_stat oc;
+          close_out oc
+      with _ -> ())


### PR DESCRIPTION
the stats were only displayed when the Gc module load was triggered by a specific call, which didn't happen often. I could have just forced the load of the module through a dummy call from `std_exit.ml`, but removing the previous changes and adding a separate `std_init.ml` to load a `at_exit` hook the standard way felt much cleaner.
