### PR TITLE
Avoid subfunction inlining when no application expressions present

### DIFF
--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -276,6 +276,7 @@ module Result = struct
       used_staticfail : Static_exception.Set.t;
       inlining_threshold : Inlining_cost.inlining_threshold;
       benefit : Inlining_cost.Benefit.t;
+      num_direct_applications : int;
     }
 
   let create ~round =
@@ -283,6 +284,7 @@ module Result = struct
       used_staticfail = Static_exception.Set.empty;
       inlining_threshold = initial_inlining_threshold ~round;
       benefit = Inlining_cost.Benefit.zero;
+      num_direct_applications = 0;
     }
 
   let approx t = t.approx
@@ -310,4 +312,10 @@ module Result = struct
     { t with inlining_threshold }
 
   let inlining_threshold t = t.inlining_threshold
+
+  let seen_direct_application t =
+    { t with num_direct_applications = t.num_direct_applications + 1; }
+
+  let num_direct_applications t =
+    t.num_direct_applications
 end

--- a/middle_end/inline_and_simplify_aux.mli
+++ b/middle_end/inline_and_simplify_aux.mli
@@ -228,6 +228,9 @@ module Result : sig
 
   val set_inlining_threshold : t -> Inlining_cost.inlining_threshold -> t
   val inlining_threshold : t -> Inlining_cost.inlining_threshold
+
+  val seen_direct_application : t -> t
+  val num_direct_applications : t -> int
 end
 
 (** Command line argument -inline *)

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -98,6 +98,10 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
       ~function_decls ~lhs_of_application ~closure_id_being_applied
       ~inline_requested ~function_decl ~args ~simplify
   in
+  let num_direct_applications_seen =
+    (R.num_direct_applications r_inlined) - (R.num_direct_applications r)
+  in
+  assert (num_direct_applications_seen >= 0);
   let keep_inlined_version =
     if function_decl.stub then begin
       made_decision (Inlined (Copying_body Stub));
@@ -164,10 +168,14 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
       else E.inlining_level_up env
     in
     simplify env r body
-  end else begin
+  end else if num_direct_applications_seen < 1 then begin
     (* Inlining the body of the function did not appear sufficiently
        beneficial; however, it may become so if we inline within the body
-       first.  We try that next. *)
+       first.  We try that next, unless it is known that there are were
+       no direct applications in the simplified body computed above, meaning
+       no opportunities for inlining. *)
+      no_simplification ()
+  end else begin
     let body, r_inlined =
       Inlining_transforms.inline_by_copying_function_body ~env
         ~r:(R.reset_benefit r)
@@ -368,7 +376,7 @@ let for_call_site ~env ~r ~(function_decls : Flambda.function_declarations)
       kind = Direct closure_id_being_applied;
       dbg;
       inline = inline_requested;
-    }, R.set_approx r (A.value_unknown Other)
+    }, R.set_approx (R.seen_direct_application r) (A.value_unknown Other)
   in
   let max_level =
     match !Clflags.max_inlining_depth with


### PR DESCRIPTION
Having tried the first stage of non-recursive inlining and failed, if we know that the output of that simplification pass contains no direct application points, then subfunction inlining seems doomed to fail as well.

I think the only place that a direct application is created which does not get run through simplify itself is in the [no_simplification] function.  As such, that's the only place that needs to call [R.seen_direct_application], I think.
