### PR TITLE
Attempt to fix ocamlobjinfo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -661,7 +661,7 @@ clean::
 # Tools
 
 ocamltools: ocamlc ocamlyacc ocamllex asmcomp/cmx_format.cmi \
-            asmcomp/printclambda.cmo
+            compilerlibs/ocamloptcomp.cma
 	cd tools; $(MAKE) all
 
 ocamltoolsopt: ocamlopt

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -18,8 +18,8 @@ CAMLC=$(CAMLRUN) ../boot/ocamlc -nostdlib -I ../boot
 CAMLOPT=$(CAMLRUN) ../ocamlopt -nostdlib -I ../stdlib
 CAMLLEX=$(CAMLRUN) ../boot/ocamllex
 INCLUDES=-I ../utils -I ../parsing -I ../typing -I ../bytecomp -I ../asmcomp \
-	 -I ../driver -I ../toplevel
-COMPFLAGS= -strict-sequence -w +27+32..39 -warn-error A -safe-string $(INCLUDES)
+	 -I ../middle_end -I ../middle_end/base_types -I ../driver -I ../toplevel
+COMPFLAGS= -strict-sequence -w +27+32..39 -warn-error A-51 -safe-string $(INCLUDES)
 LINKFLAGS=$(INCLUDES)
 
 all: ocamldep ocamlprof ocamlcp ocamloptp ocamlmktop ocamlmklib dumpobj \
@@ -270,7 +270,7 @@ objinfo_helper$(EXE): objinfo_helper.c ../config/s.h
 
 OBJINFO=../compilerlibs/ocamlcommon.cma \
         ../compilerlibs/ocamlbytecomp.cma \
-        ../asmcomp/printclambda.cmo \
+        ../compilerlibs/ocamloptcomp.cma \
         objinfo.cmo
 
 objinfo: objinfo_helper$(EXE) $(OBJINFO)

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -98,7 +98,7 @@ let print_cmt_infos cmt =
      | None -> ""
      | Some crc -> Digest.to_hex crc)
 
-let print_general_infos name crc defines cmi cmx =
+let print_general_infos name crc defines cmi import_cmx =
   printf "Name: %s\n" name;
   printf "CRC of implementation: %s\n" (Digest.to_hex crc);
   printf "Globals defined:\n";
@@ -106,15 +106,21 @@ let print_general_infos name crc defines cmi cmx =
   printf "Interfaces imported:\n";
   List.iter print_name_crc cmi;
   printf "Implementations imported:\n";
-  List.iter print_name_crc cmx
+  List.iter print_name_crc import_cmx
 
 open Cmx_format
 
 let print_cmx_infos (ui, crc) =
   print_general_infos
-    ui.ui_name crc ui.ui_defines ui.ui_imports_cmi ui.ui_imports_cmx;
+    ui.ui_name crc ui.ui_defines ui.ui_imports_cmi
+    ui.ui_imports_cmx;
   (* CR mshinwell: This should print the flambda export info.
      Unfortunately this needs some surgery in the Makefiles. *)
+  let cu = Compilation_unit.create (Ident.create_persistent ui.ui_name)
+    (Linkage_name.create "__dummy__") in
+  Compilation_unit.set_current cu;
+  printf "Implementation exported:\n";
+  Format.eprintf "%a" Export_info.print_all ui.ui_export_info;
   let pr_funs _ fns =
     List.iter (fun arity -> printf " %d" arity) fns in
   printf "Currying functions:%a\n" pr_funs ui.ui_curry_fun;

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -120,7 +120,10 @@ let print_cmx_infos (ui, crc) =
     (Linkage_name.create "__dummy__") in
   Compilation_unit.set_current cu;
   printf "Implementation exported:\n";
-  Format.eprintf "%a" Export_info.print_all ui.ui_export_info;
+  begin match ui.ui_export_info with
+  | Clambda approx -> Format.printf " %a\n" Printclambda.approx approx
+  | Flambda export -> Format.printf " %a\n" Export_info.print_all export
+  end;
   let pr_funs _ fns =
     List.iter (fun arity -> printf " %d" arity) fns in
   printf "Currying functions:%a\n" pr_funs ui.ui_curry_fun;


### PR DESCRIPTION
Here is my attempt to fix ocamlobjinfo to dump export info for cmx
1. Makefiles are fixed to link module from `middle_end` when compiling `objinfo.ml`
2. A `compilation_unit.t` is created and set before printing
3. `Export_info.print_all` is used to print export infos
