### PR TITLE
Rewrite the inlining stats output

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -274,9 +274,9 @@ let read_one_param ppf position name v =
       | "no-inline-recursive-functions" ->
           clear "no-inline-recursive-functions" [ inline_recursive_functions ] v
 
-      | "inlining-stats" ->
+      | "inlining-report" ->
           if !native_code then
-            set "inlining-stats" [ inlining_stats ] v
+            set "inlining-report" [ inlining_stats ] v
 
       | "timings" -> set "timings" [ print_timings ] v
       | "flambda-verbose" ->

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -127,7 +127,7 @@ let mk_inline_toplevel f =
 ;;
 
 let mk_inlining_stats f =
-  "-inlining-stats", Arg.Unit f, " Emit `.<round>.inlining' file(s) (one per \
+  "-inlining-report", Arg.Unit f, " Emit `.<round>.inlining' file(s) (one per \
       round) showing the inliner's decisions"
 ;;
 

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -632,7 +632,7 @@ and simplify_set_of_closures original_env r
       E.enter_closure closure_env ~closure_id:(Closure_id.wrap fid)
         ~inline_inside:
           (Inlining_decision.should_inline_inside_declaration function_decl)
-        ~where:Transform_set_of_closures_expression
+        ~debuginfo:function_decl.dbg
         ~f:(fun body_env -> simplify body_env r function_decl.body)
     in
     let inline : Lambda.inline_attribute =

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -244,21 +244,44 @@ module Env = struct
 
   (* CR-soon mshinwell: this is a bit contorted (see use in
      inlining_decision.ml) *)
-  let note_entering_closure t ~closure_id ~where =
+  let note_entering_closure t ~closure_id ~debuginfo =
     { t with
       inlining_stats_closure_stack =
         Inlining_stats.Closure_stack.note_entering_closure
-          t.inlining_stats_closure_stack ~closure_id ~where;
+          t.inlining_stats_closure_stack ~closure_id ~debuginfo;
     }
 
-  let enter_closure t ~closure_id ~inline_inside ~where ~f =
+  let note_entering_call t ~closure_id ~debuginfo =
+    { t with
+      inlining_stats_closure_stack =
+        Inlining_stats.Closure_stack.note_entering_call
+          t.inlining_stats_closure_stack ~closure_id ~debuginfo;
+    }
+
+  let note_entering_inlined t =
+    { t with
+      inlining_stats_closure_stack =
+        Inlining_stats.Closure_stack.note_entering_inlined
+          t.inlining_stats_closure_stack;
+    }
+
+  let note_entering_specialised t ~closure_ids =
+    { t with
+      inlining_stats_closure_stack =
+        Inlining_stats.Closure_stack.note_entering_specialised
+          t.inlining_stats_closure_stack ~closure_ids;
+    }
+
+  let enter_closure t ~closure_id ~inline_inside ~debuginfo ~f =
     let t =
       if inline_inside then t
       else set_never_inline t
     in
-    f (note_entering_closure t ~closure_id ~where)
+    f (note_entering_closure t ~closure_id ~debuginfo)
 
-  let inlining_stats_closure_stack t = t.inlining_stats_closure_stack
+  let record_decision t decision =
+    Inlining_stats.record_decision decision
+      ~closure_stack:t.inlining_stats_closure_stack
 end
 
 let initial_inlining_threshold ~round : Inlining_cost.Threshold.t =

--- a/middle_end/inline_and_simplify_aux.mli
+++ b/middle_end/inline_and_simplify_aux.mli
@@ -161,8 +161,28 @@ module Env : sig
   val note_entering_closure
      : t
     -> closure_id:Closure_id.t
-    -> where:Inlining_stats_types.where_entering_closure
+    -> debuginfo:Debuginfo.t
     -> t
+
+   (** If collecting inlining statistics, record that the inliner is about to
+       descend into a call to [closure_id].  This information enables us to
+       produce a stack of closures that form a kind of context around an
+       inlining decision point. *)
+  val note_entering_call
+     : t
+    -> closure_id:Closure_id.t
+    -> debuginfo:Debuginfo.t
+    -> t
+
+   (** If collecting inlining statistics, record that the inliner is about to
+       descend into an inlined function call.  This requires that the inliner
+       has already entered the call with [note_entering_call]. *)
+  val note_entering_inlined : t -> t
+
+   (** If collecting inlining statistics, record that the inliner is about to
+       descend into a specialised function definition.  This requires that the
+       inliner has already entered the call with [note_entering_call]. *)
+  val note_entering_specialised : t -> closure_ids:Closure_id.Set.t -> t
 
   (** Update a given environment to record that the inliner is about to
       descend into [closure_id] and pass the resulting environment to [f].
@@ -172,15 +192,17 @@ module Env : sig
      : t
     -> closure_id:Closure_id.t
     -> inline_inside:bool
-    -> where:Inlining_stats_types.where_entering_closure
+    -> debuginfo:Debuginfo.t
     -> f:(t -> 'a)
     -> 'a
 
-  (** Return the closure stack, used for the generation of inlining statistics,
-      stored inside the given environment. *)
-  val inlining_stats_closure_stack
+   (** If collecting inlining statistics, record an inlining decision for the
+       call at the top of the closure stack stored inside the given
+       environment. *)
+  val record_decision
      : t
-    -> Inlining_stats.Closure_stack.t
+    -> Inlining_stats_types.Decision.t
+    -> unit
 
   (** Print a human-readable version of the given environment. *)
   val print : Format.formatter -> t -> unit

--- a/middle_end/inlining_cost.mli
+++ b/middle_end/inlining_cost.mli
@@ -109,6 +109,8 @@ module Whether_sufficient_benefit : sig
   val evaluate : t -> bool
 
   val to_string : t -> string
+
+  val print_description : subfunctions:bool -> Format.formatter -> t -> unit
 end
 
 val scale_inline_threshold_by : int

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -20,13 +20,18 @@ module R = Inline_and_simplify_aux.Result
 module U = Flambda_utils
 module W = Inlining_cost.Whether_sufficient_benefit
 module T = Inlining_cost.Threshold
+module S = Inlining_stats_types
+module D = S.Decision
+
+type inlining_result =
+  | Changed of (Flambda.t * R.t)
+  | Original
 
 let inline_non_recursive env r ~function_decls ~lhs_of_application
     ~closure_id_being_applied ~(function_decl : Flambda.function_declaration)
     ~value_set_of_closures ~only_use_of_function ~original
     ~(args : Variable.t list) ~size_from_approximation ~simplify
-    ~always_inline ~(inline_requested : Lambda.inline_attribute)
-    ~(made_decision : Inlining_stats_types.Decision.t -> unit) =
+    ~always_inline ~(inline_requested : Lambda.inline_attribute) =
   (* When all of the arguments to the function being inlined are unknown, then
      we cannot materially simplify the function.  As such, we know what the
      benefit of inlining it would be: just removing the call.  In this case
@@ -58,7 +63,7 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
   let known_to_have_no_benefit =
     if function_decl.stub || only_use_of_function || always_inline
          || (toplevel && branch_depth = 0) then
-      false
+      None
     else if A.all_not_useful (E.find_list_exn env args) then
       match size_from_approximation with
       | Some body_size ->
@@ -90,25 +95,24 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
             ~benefit
         in
         if (not (W.evaluate wsb)) then begin
-          made_decision (Tried (Copying_body (Evaluated wsb)));
-          true
-        end else false
+          Some
+            (S.Inlined.Not_inlined (Without_subfunctions wsb))
+        end else None
       | None ->
         (* The function is definitely too large to inline given that we don't
            have any approximations for its arguments.  Further, the body
            should already have been simplified (inside its declaration), so
            we also expect no gain from the code below that permits inlining
            inside the body. *)
-        made_decision (Tried (Copying_body Evaluated_unspecialized));
-        true
+        Some (S.Inlined.Not_inlined Unspecialized)
     else begin
       (* There are useful approximations, so we should simplify. *)
-      false
+      None
     end
   in
-  if known_to_have_no_benefit then begin
-    None
-  end else begin
+  match known_to_have_no_benefit with
+  | Some descision -> (Original, (D.Nonrecursive descision))
+  | None -> begin
     let body, r_inlined =
       (* First we construct the code that would result from copying the body of
          the function, without doing any further inlining upon it, to the call
@@ -124,37 +128,7 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
       (R.num_direct_applications r_inlined) - (R.num_direct_applications r)
     in
     assert (num_direct_applications_seen >= 0);
-    let keep_inlined_version =
-      if function_decl.stub then begin
-        made_decision (Inlined (Copying_body Stub));
-        true
-      end else if always_inline then begin
-        made_decision (Inlined (Copying_body Unconditionally));
-        true
-      end else if only_use_of_function then begin
-        made_decision (Inlined (Copying_body Decl_local_to_application));
-        true
-      end else begin
-        let sufficient_benefit =
-          W.create ~original body
-            ~toplevel:(E.at_toplevel env)
-            ~branch_depth:(E.branch_depth env)
-            ~lifting:function_decl.Flambda.is_a_functor
-            ~round:(E.round env)
-            ~benefit:(R.benefit r_inlined)
-        in
-        let keep_inlined_version = W.evaluate sufficient_benefit in
-        let decision : Inlining_stats_types.Decision.t =
-          if keep_inlined_version then
-            Inlined (Copying_body (Evaluated sufficient_benefit))
-          else
-            Tried (Copying_body (Evaluated sufficient_benefit))
-        in
-        made_decision decision;
-        keep_inlined_version
-      end
-    in
-    if keep_inlined_version then begin
+    let keep_inlined_version decision =
       (* Inlining the body of the function was sufficiently beneficial that we
          will keep it, replacing the call site.  We continue by allowing
          further inlining within the inlined copy of the body. *)
@@ -176,10 +150,7 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
       (* [lift_lets_expr] aims to clean up bindings introduced by the
          inlining. *)
       let body = Lift_code.lift_lets_expr body ~toplevel:true in
-      let env =
-        E.note_entering_closure env ~closure_id:closure_id_being_applied
-          ~where:Inline_by_copying_function_body
-      in
+      let env = E.note_entering_inlined env in
       let env =
         if function_decl.stub ||
            (* Stub functions should not prevent other functions
@@ -191,22 +162,16 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
         then env
         else E.inlining_level_up env
       in
-      Some (simplify env r body)
-    end else if num_direct_applications_seen < 1 then begin
-      (* Inlining the body of the function did not appear sufficiently
-         beneficial; however, it may become so if we inline within the body
-         first.  We try that next, unless it is known that there are were
-         no direct applications in the simplified body computed above, meaning
-         no opportunities for inlining. *)
-        None
-    end else begin
-      let body, r_inlined =
-        Inlining_transforms.inline_by_copying_function_body ~env
-          ~r:(R.reset_benefit r)
-          ~function_decls ~lhs_of_application ~closure_id_being_applied
-          ~inline_requested ~function_decl ~args ~simplify
-      in
-      let wsb =
+      (Changed (simplify env r body), decision)
+    in
+    if function_decl.stub then
+      keep_inlined_version (D.Nonrecursive (Inlined Stub))
+    else if always_inline then
+      keep_inlined_version (D.Nonrecursive (Inlined Unconditionally))
+    else if only_use_of_function then
+      keep_inlined_version (D.Nonrecursive (Inlined Decl_local_to_application))
+    else begin
+      let sufficient_benefit =
         W.create ~original body
           ~toplevel:(E.at_toplevel env)
           ~branch_depth:(E.branch_depth env)
@@ -214,28 +179,60 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
           ~round:(E.round env)
           ~benefit:(R.benefit r_inlined)
       in
-      let keep_inlined_version = W.evaluate wsb in
-      let decision : Inlining_stats_types.Decision.t =
-        if keep_inlined_version then
-          (* CR mshinwell: This "with_subfunctions" name isn't
-             descriptive enough. *)
-          Inlined (Copying_body_with_subfunctions (Evaluated wsb))
-        else
-          Tried (Copying_body_with_subfunctions (Evaluated wsb))
-      in
-      made_decision decision;
-      if keep_inlined_version then begin
-        Some (body, R.map_benefit r_inlined
-          (Inlining_cost.Benefit.(+) (R.benefit r)))
-      end
-      else begin
-        (* r_inlined contains an approximation that may be invalid for the
-           untransformed expression: it may reference functions that only
-           exists if the body of the function is in fact inlined.
-           If the function approximation contained an approximation that
-           does not depend on the actual values of its arguments, it
-           could be returned instead of [A.value_unknown]. *)
-        None
+      if W.evaluate sufficient_benefit then
+        keep_inlined_version
+          (D.Nonrecursive
+             (Inlined (Without_subfunctions sufficient_benefit)))
+      else if num_direct_applications_seen < 1 then begin
+      (* Inlining the body of the function did not appear sufficiently
+         beneficial; however, it may become so if we inline within the body
+         first.  We try that next, unless it is known that there are were
+         no direct applications in the simplified body computed above, meaning
+         no opportunities for inlining. *)
+        let decision =
+          D.Nonrecursive
+            (Not_inlined (Without_subfunctions sufficient_benefit))
+        in
+        (Original, decision)
+      end else begin
+        let body, r_inlined =
+          Inlining_transforms.inline_by_copying_function_body ~env
+            ~r:(R.reset_benefit r)
+            ~function_decls ~lhs_of_application ~closure_id_being_applied
+            ~inline_requested ~function_decl ~args ~simplify
+        in
+        let wsb =
+          W.create ~original body
+            ~toplevel:(E.at_toplevel env)
+            ~branch_depth:(E.branch_depth env)
+            ~lifting:function_decl.Flambda.is_a_functor
+            ~round:(E.round env)
+            ~benefit:(R.benefit r_inlined)
+        in
+        if W.evaluate wsb then begin
+          let res =
+            (body, R.map_benefit r_inlined
+                     (Inlining_cost.Benefit.(+) (R.benefit r)))
+          in
+          let decision =
+            D.Nonrecursive
+              (Inlined (With_subfunctions(sufficient_benefit, wsb)))
+          in
+          (Changed res, decision)
+        end
+        else begin
+          (* r_inlined contains an approximation that may be invalid for the
+             untransformed expression: it may reference functions that only
+             exists if the body of the function is in fact inlined.
+             If the function approximation contained an approximation that
+             does not depend on the actual values of its arguments, it
+             could be returned instead of [A.value_unknown]. *)
+          let decision =
+            D.Nonrecursive
+              (Not_inlined (With_subfunctions(sufficient_benefit, wsb)))
+          in
+          (Original, decision)
+        end
       end
     end
   end
@@ -243,56 +240,44 @@ let inline_non_recursive env r ~function_decls ~lhs_of_application
 let unroll_recursive env r ~max_level ~lhs_of_application
       ~(function_decls : Flambda.function_declarations)
       ~closure_id_being_applied ~function_decl ~args ~simplify
-      ~original
-      ~(made_decision : Inlining_stats_types.Decision.t -> unit) =
-  let tried_unrolling = ref false in
-  let result =
-    if E.unrolling_allowed env && E.inlining_level env <= max_level then
-      let self_unrolling =
-        E.inside_set_of_closures_declaration function_decls.set_of_closures_id
-          env
+      ~original =
+  if E.unrolling_allowed env && E.inlining_level env <= max_level then
+    let self_unrolling =
+      E.inside_set_of_closures_declaration function_decls.set_of_closures_id
+        env
+    in
+    if self_unrolling then
+      (* CR mshinwell for pchambart: Should we really completely
+         disallow this?  (Maybe there should be a compiler option?) *)
+      (Original, S.Unrolled.Unrolling_not_tried)
+    else begin
+      let env = E.inside_unrolled_function env in
+      let body, r_inlined =
+        Inlining_transforms.inline_by_copying_function_body ~env
+          ~r:(R.reset_benefit r) ~function_decls ~lhs_of_application
+          ~inline_requested:Default_inline
+          ~closure_id_being_applied ~function_decl ~args ~simplify
       in
-      if self_unrolling then
-        (* CR mshinwell for pchambart: Should we really completely
-           disallow this?  (Maybe there should be a compiler option?) *)
-        None
-      else begin
-        let env = E.inside_unrolled_function env in
-        let body, r_inlined =
-          Inlining_transforms.inline_by_copying_function_body ~env
-            ~r:(R.reset_benefit r) ~function_decls ~lhs_of_application
-            ~inline_requested:Default_inline
-            ~closure_id_being_applied ~function_decl ~args ~simplify
+      let wsb =
+        W.create body ~original
+          ~toplevel:(E.at_toplevel env)
+          ~branch_depth:(E.branch_depth env)
+          ~lifting:false
+          ~round:(E.round env)
+          ~benefit:(R.benefit r_inlined)
+      in
+      if W.evaluate wsb then begin
+        let r =
+          R.map_benefit r_inlined (Inlining_cost.Benefit.(+) (R.benefit r))
         in
-        tried_unrolling := true;
-        let wsb =
-          W.create body ~original
-            ~toplevel:(E.at_toplevel env)
-            ~branch_depth:(E.branch_depth env)
-            ~lifting:false
-            ~round:(E.round env)
-            ~benefit:(R.benefit r_inlined)
-        in
-        let keep_unrolled_version =
-          if W.evaluate wsb then begin
-            made_decision (Inlined (Unrolled wsb));
-            true
-          end else begin
-            (* No decision is recorded here; we will try another strategy
-               below, and then record that we also tried to unroll. *)
-            false
-          end
-        in
-        if keep_unrolled_version then
-          let r =
-            R.map_benefit r_inlined (Inlining_cost.Benefit.(+) (R.benefit r))
-          in
-          Some (body, r)
-        else None
+        (Changed (body, r), S.Unrolled.Unrolled wsb)
+      end else begin
+        (* No decision is recorded here; we will try another strategy
+           below, and then record that we also tried to unroll. *)
+        (Original, S.Unrolled.Not_unrolled wsb)
       end
-    else None
-  in
-  !tried_unrolling, result
+    end
+  else (Original, S.Unrolled.Unrolling_not_tried)
 
 let should_duplicate_recursive_function env
       ~(function_decl : Flambda.function_declaration)
@@ -317,17 +302,17 @@ let inline_recursive env r ~max_level ~lhs_of_application
       ~(function_decls : Flambda.function_declarations)
       ~closure_id_being_applied ~function_decl
       ~(value_set_of_closures : Simple_value_approx.value_set_of_closures)
-      ~args ~args_approxs ~dbg ~simplify ~original
-      ~(made_decision : Inlining_stats_types.Decision.t -> unit) =
-  let tried_unrolling, unrolling_result =
+      ~args ~args_approxs ~dbg ~simplify ~original =
+  let unrolling_result, unrolling_decision =
     (* First try unrolling the recursive call, if we're allowed to. *)
     unroll_recursive env r ~max_level ~lhs_of_application ~function_decls
       ~closure_id_being_applied ~function_decl ~args ~simplify
-      ~original ~made_decision
+      ~original
   in
   match unrolling_result with
-  | Some _ -> unrolling_result
-  | None ->
+  | Changed _ ->
+    unrolling_result, D.Recursive(unrolling_decision, Specialising_not_tried)
+  | Original ->
     (* If unrolling failed, consider duplicating the whole function
        declaration at the call site, specialising parameters whose arguments
        we know. *)
@@ -347,34 +332,35 @@ let inline_recursive env r ~max_level ~lhs_of_application
       | Some (expr, r_inlined) ->
         let wsb =
           W.create ~original expr
-            ~toplevel:(E.at_toplevel env)
+            ~toplevel:false
             ~branch_depth:(E.branch_depth env)
             ~lifting:false
             ~round:(E.round env)
             ~benefit:(R.benefit r_inlined)
         in
-        let keep_inlined_version = W.evaluate wsb in
-        let decision : Inlining_stats_types.Decision.t =
-          if keep_inlined_version then
-            Inlined (Copying_decl (Tried_unrolling tried_unrolling, wsb))
-          else
-            Tried (Copying_decl (Tried_unrolling tried_unrolling, wsb))
-        in
-        made_decision decision;
-        if keep_inlined_version then
+        if W.evaluate wsb then begin
           let r =
             R.map_benefit r_inlined (Inlining_cost.Benefit.(+) (R.benefit r))
           in
-          Some (expr, r)
-        else
-          None
-      | None -> None
+          let decision =
+            D.Recursive (unrolling_decision, Specialised wsb)
+          in
+          (Changed (expr, r), decision)
+        end else begin
+          let decision =
+            D.Recursive (unrolling_decision, Not_specialised wsb)
+          in
+          (Original, decision)
+        end
+      | None ->
+        let decision =
+          D.Recursive (unrolling_decision, Specialising_not_tried)
+        in
+        (Original, decision)
     else begin
       (* CR lwhite: should include details of why it was not attempted
          in the reason. *)
-      made_decision
-        (Did_not_try_copying_decl (Tried_unrolling tried_unrolling));
-      None
+      (Original, D.Recursive (unrolling_decision, Specialising_not_tried))
     end
 
 let for_call_site ~env ~r ~(function_decls : Flambda.function_declarations)
@@ -386,13 +372,6 @@ let for_call_site ~env ~r ~(function_decls : Flambda.function_declarations)
     Misc.fatal_error "Inlining_decision.for_call_site: inconsistent lengths \
         of [args] and [args_approxs]"
   end;
-  let made_decision =
-    let closure_stack =
-      E.inlining_stats_closure_stack (E.note_entering_closure env
-          ~closure_id:closure_id_being_applied ~where:Inlining_decision)
-    in
-    Inlining_stats.record_decision ~closure_stack ~debuginfo:dbg
-  in
   let original =
     Flambda.Apply {
       func = lhs_of_application;
@@ -405,142 +384,148 @@ let for_call_site ~env ~r ~(function_decls : Flambda.function_declarations)
   let original_r =
     R.set_approx (R.seen_direct_application r) (A.value_unknown Other)
   in
-  let max_level =
-    Clflags.Int_arg_helper.get ~key:(E.round env) !Clflags.max_inlining_depth
-  in
-  let inline_annotation =
-    (* Merge call site annotation and function annotation.
-       The call site annotation takes precedence *)
-    match (inline_requested : Lambda.inline_attribute) with
-    | Default_inline -> function_decl.inline
-    | Always_inline | Never_inline -> inline_requested
-  in
-  let always_inline =
-    match (inline_annotation : Lambda.inline_attribute) with
-    | Always_inline -> true
-    (* CR-someday mshinwell: consider whether there could be better
-       behaviour for stubs *)
-    | Never_inline | Default_inline -> false
-  in
-  let is_a_stub = function_decl.stub in
-  let num_params = List.length function_decl.params in
-  let only_use_of_function = false in
-  let raw_inlining_threshold = R.inlining_threshold r in
-  let max_inlining_threshold =
-    if E.at_toplevel env then
-      Inline_and_simplify_aux.initial_inlining_toplevel_threshold
-        ~round:(E.round env)
-    else
-      Inline_and_simplify_aux.initial_inlining_threshold ~round:(E.round env)
-  in
-  let unthrottled_inlining_threshold =
-    match raw_inlining_threshold with
-    | None -> max_inlining_threshold
-    | Some inlining_threshold -> inlining_threshold
-  in
-  let inlining_threshold =
-    T.min unthrottled_inlining_threshold max_inlining_threshold
-  in
-  let inlining_threshold_diff =
-    T.sub unthrottled_inlining_threshold inlining_threshold
-  in
-  let fun_var =
-    U.find_declaration_variable closure_id_being_applied function_decls
-  in
-  let recursive_functions =
-    lazy
-      (Find_recursive_functions.in_function_declarations function_decls
-         ~backend:(E.backend env))
-  in
-  let recursive =
-    lazy (Variable.Set.mem fun_var (Lazy.force recursive_functions))
-  in
-  let fun_cost : Inlining_cost.Threshold.t =
-    match (inline_annotation : Lambda.inline_attribute) with
-    | Never_inline -> Never_inline
-    | Always_inline | Default_inline ->
-      if always_inline
-        || is_a_stub
-        || (only_use_of_function && not (Lazy.force recursive))
-      then
-        inlining_threshold
-      else begin
-        Inlining_cost.can_try_inlining function_decl.body inlining_threshold
-          ~number_of_arguments:num_params
-          (* CR mshinwell: for the moment, this is None, since the
-             Inlining_cost code isn't checking sizes up to the max inlining
-             threshold---this seems to take too long. *)
-          ~size_from_approximation:None
-      end
-  in
-  let simpl =
-    if E.never_inline env then
-      (* This case only occurs when examining the body of a stub function
-         but not in the context of inlining said function.  As such, there
-         is nothing to do here (and no decision to report). *)
-      None
-    else if fun_cost = T.Never_inline && not function_decl.stub then
-      (* CR pchambart: should we also accept unconditionnal inline ?
-         It is some kind of user defined stub, but if we restrict to stub
-         we are certain that no abusive use of [@@inline] can blow things up *)
-      let reason : Inlining_stats_types.Decision.t =
-        match inlining_threshold with
-        | Never_inline ->
-          Function_prevented_from_inlining
-        | Can_inline_if_no_larger_than threshold ->
-          Function_obviously_too_large threshold
-      in
-      made_decision reason;
-      None
-    else
-      let remaining_inlining_threshold = fun_cost in
-      let r = R.set_inlining_threshold r (Some remaining_inlining_threshold) in
-      (* Try inlining if the function is non-recursive and not too far above
-         the threshold (or if the function is to be unconditionally
-         inlined). *)
-      (* CR mshinwell for pchambart: I don't understand why this was applying
-         inline_non_recursive to recursive functions. *)
-      if is_a_stub
-        || (E.inlining_level env < max_level
-            (* The classic heuristic completely disables inlining if the
-               function is not annotated as to be inlined. *)
-            && (always_inline || not !Clflags.classic_inlining)
-            && not (Lazy.force recursive))
-      then
-        let size_from_approximation =
-          match
-            Variable.Map.find fun_var (Lazy.force value_set_of_closures.size)
-          with
-          | size -> size
-          | exception Not_found ->
-            Misc.fatal_errorf "Approximation does not give a size for the \
-                function having fun_var %a.  value_set_of_closures: %a"
-              Variable.print fun_var
-              A.print_value_set_of_closures value_set_of_closures
+  if E.never_inline env then
+    (* This case only occurs when examining the body of a stub function
+       but not in the context of inlining said function.  As such, there
+       is nothing to do here (and no decision to report). *)
+    original, original_r
+  else begin
+    let env =
+      E.note_entering_call env
+        ~closure_id:closure_id_being_applied ~debuginfo:dbg
+    in
+    let max_level =
+      Clflags.Int_arg_helper.get ~key:(E.round env) !Clflags.max_inlining_depth
+    in
+    let inline_annotation =
+      (* Merge call site annotation and function annotation.
+         The call site annotation takes precedence *)
+      match (inline_requested : Lambda.inline_attribute) with
+      | Default_inline -> function_decl.inline
+      | Always_inline | Never_inline -> inline_requested
+    in
+    let always_inline =
+      match (inline_annotation : Lambda.inline_attribute) with
+      | Always_inline -> true
+      (* CR-someday mshinwell: consider whether there could be better
+         behaviour for stubs *)
+      | Never_inline | Default_inline -> false
+    in
+    let is_a_stub = function_decl.stub in
+    let num_params = List.length function_decl.params in
+    let only_use_of_function = false in
+    let raw_inlining_threshold = R.inlining_threshold r in
+    let max_inlining_threshold =
+      if E.at_toplevel env then
+        Inline_and_simplify_aux.initial_inlining_toplevel_threshold
+          ~round:(E.round env)
+      else
+        Inline_and_simplify_aux.initial_inlining_threshold ~round:(E.round env)
+    in
+    let unthrottled_inlining_threshold =
+      match raw_inlining_threshold with
+      | None -> max_inlining_threshold
+      | Some inlining_threshold -> inlining_threshold
+    in
+    let inlining_threshold =
+      T.min unthrottled_inlining_threshold max_inlining_threshold
+    in
+    let inlining_threshold_diff =
+      T.sub unthrottled_inlining_threshold inlining_threshold
+    in
+    let fun_var =
+      U.find_declaration_variable closure_id_being_applied function_decls
+    in
+    let recursive_functions =
+      lazy
+        (Find_recursive_functions.in_function_declarations function_decls
+           ~backend:(E.backend env))
+    in
+    let recursive =
+      lazy (Variable.Set.mem fun_var (Lazy.force recursive_functions))
+    in
+    let fun_cost : Inlining_cost.Threshold.t =
+      match (inline_annotation : Lambda.inline_attribute) with
+      | Never_inline -> Never_inline
+      | Always_inline | Default_inline ->
+        if always_inline
+          || is_a_stub
+          || (only_use_of_function && not (Lazy.force recursive))
+        then
+          inlining_threshold
+        else begin
+          Inlining_cost.can_try_inlining function_decl.body inlining_threshold
+            ~number_of_arguments:num_params
+            (* CR mshinwell: for the moment, this is None, since the
+               Inlining_cost code isn't checking sizes up to the max inlining
+               threshold---this seems to take too long. *)
+            ~size_from_approximation:None
+        end
+    in
+    let simpl, decision =
+      if fun_cost = T.Never_inline && not function_decl.stub then
+        (* CR pchambart: should we also accept unconditionnal inline ?  It is
+           some kind of user defined stub, but if we restrict to stub we are
+           certain that no abusive use of [@@inline] can blow things up *)
+        let reason : Inlining_stats_types.Prevented.t =
+          match inlining_threshold with
+          | Never_inline ->
+            Function_prevented_from_inlining
+          | Can_inline_if_no_larger_than threshold ->
+            Function_obviously_too_large threshold
         in
-        inline_non_recursive env r ~function_decls ~lhs_of_application
-          ~closure_id_being_applied ~function_decl ~value_set_of_closures
-          ~made_decision ~only_use_of_function ~original
-          ~inline_requested ~always_inline ~args ~size_from_approximation
-          ~simplify
-      else if E.inlining_level env >= max_level then begin
-        made_decision (Can_inline_but_tried_nothing (Level_exceeded true));
-        None
-      end else if not !Clflags.classic_inlining && Lazy.force recursive then
-        inline_recursive env r ~max_level ~lhs_of_application ~function_decls
-          ~closure_id_being_applied ~function_decl ~value_set_of_closures
-          ~args ~args_approxs ~dbg ~simplify ~original ~made_decision
-      else begin
-        made_decision (Can_inline_but_tried_nothing (Level_exceeded false));
-        None
-      end
-  in
-  match simpl with
-  | None -> original, original_r
-  | Some (expr, r) ->
-    if E.inlining_level env = 0
-    then expr, R.set_inlining_threshold r raw_inlining_threshold
-    else expr, R.add_inlining_threshold r inlining_threshold_diff
+        (Original, D.Prevented reason)
+      else
+        let remaining_inlining_threshold = fun_cost in
+        let r =
+          R.set_inlining_threshold r (Some remaining_inlining_threshold)
+        in
+        (* Try inlining if the function is non-recursive and not too far above
+           the threshold (or if the function is to be unconditionally
+           inlined). *)
+        (* CR mshinwell for pchambart: I don't understand why this was applying
+           inline_non_recursive to recursive functions. *)
+        if is_a_stub
+          || (E.inlining_level env < max_level
+              (* The classic heuristic completely disables inlining if the
+                 function is not annotated as to be inlined. *)
+              && (always_inline || not !Clflags.classic_inlining)
+              && not (Lazy.force recursive))
+        then
+          let size_from_approximation =
+            match
+              Variable.Map.find fun_var (Lazy.force value_set_of_closures.size)
+            with
+            | size -> size
+            | exception Not_found ->
+              Misc.fatal_errorf "Approximation does not give a size for the \
+                  function having fun_var %a.  value_set_of_closures: %a"
+                Variable.print fun_var
+                A.print_value_set_of_closures value_set_of_closures
+          in
+          inline_non_recursive env r ~function_decls ~lhs_of_application
+            ~closure_id_being_applied ~function_decl ~value_set_of_closures
+            ~only_use_of_function ~original
+            ~inline_requested ~always_inline ~args ~size_from_approximation
+            ~simplify
+        else if E.inlining_level env >= max_level then begin
+          (Original, D.Prevented Level_exceeded)
+        end else if not !Clflags.classic_inlining && Lazy.force recursive then
+          inline_recursive env r ~max_level ~lhs_of_application ~function_decls
+            ~closure_id_being_applied ~function_decl ~value_set_of_closures
+            ~args ~args_approxs ~dbg ~simplify ~original
+        else begin
+          (Original, D.Prevented Classic_heuristic)
+        end
+    in
+    E.record_decision env decision;
+    match simpl with
+    | Original -> original, original_r
+    | Changed (expr, r) ->
+      if E.inlining_level env = 0
+      then expr, R.set_inlining_threshold r raw_inlining_threshold
+      else expr, R.add_inlining_threshold r inlining_threshold_diff
+  end
 
 
 (* We do not inline inside stubs, which are always inlined at their call site.

--- a/middle_end/inlining_stats.ml
+++ b/middle_end/inlining_stats.ml
@@ -14,146 +14,268 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let vim_trailer = "vim:fdm=expr:filetype=plain:\
+let _vim_trailer = "vim:fdm=expr:filetype=plain:\
   foldexpr=getline(v\\:lnum)=~'^\\\\s*$'&&getline(v\\:lnum+1)=~'\\\\S'?'<1'\\:1"
 
 module Closure_stack = struct
-  type t
-    = (Closure_id.t * Inlining_stats_types.where_entering_closure) list
+  type t = node list
+
+  and node =
+    | Closure of Closure_id.t * Debuginfo.t
+    | Call of Closure_id.t * Debuginfo.t
+    | Inlined
+    | Specialised of Closure_id.Set.t
 
   let create () = []
 
-  let _compare t1 t2 =
-    match t1, t2 with
-    | (id1, _)::_, (id2, _)::_ ->
-      let (_ : string) = Format.flush_str_formatter () in
-      let (id1 : string) =
-        Format.fprintf Format.str_formatter "%a" Closure_id.print id1;
-        Format.flush_str_formatter ()
-      in
-      let id2 =
-        Format.fprintf Format.str_formatter "%a" Closure_id.print id2;
-        Format.flush_str_formatter ()
-      in
-      String.compare id1 id2
-    | _ -> 0
-
-  let note_entering_closure t ~closure_id ~where =
+  let note_entering_closure t ~closure_id ~debuginfo =
     if not !Clflags.inlining_stats then t
-    else t @ [closure_id, where]
+    else
+      match t with
+      | [] | (Closure _ | Inlined | Specialised _)  :: _->
+        (Closure (closure_id, debuginfo)) :: t
+      | (Call _) :: _ ->
+        Misc.fatal_errorf "note_entering_closure: unexpected Call node"
 
-  let pop = function
-    | [] -> failwith "Closure_stack.pop on empty stack"
-    | hd::tl -> (fst hd), tl
+  (* CR-someday lwhite: since calls do not have a unique id it is possible some calls
+     will end up sharing nodes. *)
+  let note_entering_call t ~closure_id ~debuginfo =
+    if not !Clflags.inlining_stats then t
+    else
+      match t with
+      | [] | (Closure _ | Inlined | Specialised _) :: _ ->
+        (Call (closure_id, debuginfo)) :: t
+      | (Call _) :: _ ->
+        Misc.fatal_errorf "note_entering_call: unexpected Call node"
 
-  let save t ~out_channel =
-    let print_elt (closure_id, where) ~last_one =
-      let current_unit = Compilation_unit.get_current_exn () in
-      let output =
-        if Closure_id.in_compilation_unit closure_id current_unit then
-          Closure_id.output
-        else
-          Closure_id.output_full
-      in
-      begin match (where : Inlining_stats_types.where_entering_closure) with
-        | Inline_by_copying_function_declaration closure_ids ->
-          let closure_ids = Closure_id.Set.remove closure_id closure_ids in
-          if Closure_id.Set.cardinal closure_ids < 1 then
-            Printf.fprintf out_channel "in copy of %a" output closure_id
-          else begin
-            Printf.fprintf out_channel "in copy of %a (and" output closure_id;
-            Closure_id.Set.iter (fun closure_id ->
-                Printf.fprintf out_channel " %a" output closure_id)
-              closure_ids;
-            Printf.fprintf out_channel ")"
-          end
-        | Transform_set_of_closures_expression ->
-          Printf.fprintf out_channel "decl of %a" output closure_id
-        | Inline_by_copying_function_body ->
-          Printf.fprintf out_channel "inlined body of %a" output closure_id
-        | Inlining_decision ->
-          Printf.fprintf out_channel "%a" output closure_id
-      end;
-      if not last_one then begin
-        match (where : Inlining_stats_types.where_entering_closure) with
-        | Inline_by_copying_function_declaration _
-        | Inline_by_copying_function_body ->
-          Printf.fprintf out_channel ": "
-        | Transform_set_of_closures_expression
-        | Inlining_decision -> Printf.fprintf out_channel " -> "
-      end
-    in
-    let rec loop = function
-      | [] -> Printf.fprintf out_channel "[]"
-      | [elt] -> print_elt elt ~last_one:true
-      | elt::elts ->
-        print_elt elt ~last_one:false;
-        loop elts
-    in
-    loop t
+  let note_entering_inlined t =
+    if not !Clflags.inlining_stats then t
+    else
+      match t with
+      | [] | (Closure _ | Inlined | Specialised _) :: _->
+        Misc.fatal_errorf "note_entering_inlined: missing Call node"
+      | (Call _) :: _ -> Inlined :: t
+
+  let note_entering_specialised t ~closure_ids =
+    if not !Clflags.inlining_stats then t
+    else
+      match t with
+      | [] | (Closure _ | Inlined | Specialised _) :: _ ->
+        Misc.fatal_errorf "note_entering_specialised: missing Call node"
+      | (Call _) :: _ -> Specialised closure_ids :: t
+
 end
 
-let time = ref 0
+let log
+  : (Closure_stack.t * Inlining_stats_types.Decision.t) list ref
+  = ref []
 
-module Line_number_then_time = struct
-  type t = Debuginfo.t * int
-
-  let compare_fst (((dbg1, t1) : t), _) (((dbg2, t2) : t), _) =
-    match compare dbg1.dinfo_line dbg2.dinfo_line with
-    | -1 -> -1
-    | 1 -> 1
-    | _ -> compare t1 t2
-
-  let create ~debuginfo ~time = debuginfo, time
-  let line_number t = (fst t).Debuginfo.dinfo_line
-end
-
-let decisions :
-  (Line_number_then_time.t
-      * (Closure_stack.t * Inlining_stats_types.Decision.t)) list
-    Closure_id.Tbl.t = Closure_id.Tbl.create 42
-
-let record_decision decision ~closure_stack ~debuginfo =
+let record_decision decision ~closure_stack =
   if !Clflags.inlining_stats then begin
-    let closure_id, closure_stack = Closure_stack.pop closure_stack in
-    let bucket =
-      match Closure_id.Tbl.find decisions closure_id with
-      | exception Not_found -> []
-      | bucket -> bucket
-    in
-    let key = Line_number_then_time.create ~debuginfo ~time:!time in
-    let data = closure_stack, decision in
-    (* The order here is important so that the "time rebasing" works
-       properly, below. *)
-    Closure_id.Tbl.replace decisions closure_id ((key, data) :: bucket);
-    incr time
+    match closure_stack with
+    | []
+    | Closure_stack.Closure _ :: _
+    | Closure_stack.Inlined :: _
+    | Closure_stack.Specialised _ :: _ ->
+      Misc.fatal_errorf "record_decision: missing Call node"
+    | Closure_stack.Call _ :: _ ->
+      log := (closure_stack, decision) :: !log
   end
 
+module Inlining_report = struct
+
+  module Place = struct
+    type kind =
+      | Closure
+      | Call
+
+    type t = Debuginfo.t * Closure_id.t * kind
+
+    let compare ((d1, cl1, k1) : t) ((d2, cl2, k2) : t) =
+      let c = compare d1.dinfo_file d2.dinfo_file in
+      if c <> 0 then c else
+      let c = compare d1.dinfo_line d2.dinfo_line in
+      if c <> 0 then c else
+      let c = compare d1.dinfo_char_end d2.dinfo_char_end in
+      if c <> 0 then c else
+      let c = compare d1.dinfo_char_start d2.dinfo_char_start in
+      if c <> 0 then c else
+      let c = Closure_id.compare cl1 cl2 in
+      if c <> 0 then c else
+        match k1, k2 with
+        | Closure, Closure -> 0
+        | Call, Call -> 0
+        | Closure, Call -> 1
+        | Call, Closure -> -1
+  end
+
+  module Place_map = Map.Make(Place)
+
+  type t = node Place_map.t
+
+  and node =
+    | Closure of t
+    | Call of call
+
+  and call =
+    { decision: Inlining_stats_types.Decision.t option;
+      inlined: t option;
+      specialised: t option; }
+
+  let empty_call =
+    { decision = None;
+      inlined = None;
+      specialised = None; }
+
+  let add_call_decision call (decision : Inlining_stats_types.Decision.t) =
+    match call.decision, decision with
+    | None, _ -> { call with decision = Some decision }
+    | Some _, Prevented _ -> call
+    | Some (Prevented _), _ -> { call with decision = Some decision }
+    | Some (Nonrecursive n1), Nonrecursive n2 -> begin
+        match n1, n2 with
+        | Not_inlined _, _ -> { call with decision = Some decision }
+        | _, _ -> call
+      end
+    | Some (Recursive (u1, s1)), Recursive (u2, s2) ->
+        let u =
+          match u1, u2 with
+          | _, Unrolling_not_tried -> u1
+          | Unrolling_not_tried, _ -> u2
+          | _, Not_unrolled _ -> u1
+          | Not_unrolled _, _ -> u2
+          | _, _ -> u1
+        in
+        let s =
+          match s1, s2 with
+          | _, Specialising_not_tried -> s1
+          | Specialising_not_tried, _ -> s2
+          | _, Not_specialised _ -> s1
+          | Not_specialised _, _ -> s2
+          | _, _ -> s1
+        in
+        let decision : Inlining_stats_types.Decision.t = Recursive (u, s) in
+        { call with decision = Some decision }
+    | Some (Recursive _), Nonrecursive _ ->
+      Misc.fatal_errorf "add_call_decision: decision kind mismatch"
+    | Some (Nonrecursive _), Recursive _ ->
+      Misc.fatal_errorf "add_call_decision: decision kind mismatch"
+
+  let add_decision t (stack, decision) =
+    let rec loop t : Closure_stack.t -> _ = function
+      | Closure(cl, dbg) :: rest ->
+          let key : Place.t = (dbg, cl, Closure) in
+          let v =
+            try
+              match Place_map.find key t with
+              | Closure v -> v
+              | Call _ -> assert false
+            with Not_found -> Place_map.empty
+          in
+          let v = loop v rest in
+          Place_map.add key (Closure v) t
+      | Call(cl, dbg) :: rest ->
+          let key : Place.t = (dbg, cl, Call) in
+          let v =
+            try
+              match Place_map.find key t with
+              | Call v -> v
+              | Closure _ -> assert false
+            with Not_found -> empty_call
+          in
+          let v =
+            match rest with
+            | [] -> add_call_decision v decision
+            | Inlined :: rest ->
+                let inlined =
+                  match v.inlined with
+                  | None -> Place_map.empty
+                  | Some inlined -> inlined
+                in
+                let inlined = loop inlined rest in
+                { v with inlined = Some inlined }
+            | Specialised _ :: rest ->
+                let specialised =
+                  match v.specialised with
+                  | None -> Place_map.empty
+                  | Some specialised -> specialised
+                in
+                let specialised = loop specialised rest in
+                { v with specialised = Some specialised }
+            | Call _ :: _ -> assert false
+            | Closure _ :: _ -> assert false
+          in
+          Place_map.add key (Call v) t
+      | [] -> assert false
+      | Inlined :: _ -> assert false
+      | Specialised _ :: _ -> assert false
+    in
+    loop t (List.rev stack)
+
+  let build log =
+    List.fold_left add_decision Place_map.empty log
+
+  let print_stars ppf n =
+    let s = String.make n '*' in
+    Format.fprintf ppf "%s" s
+
+  let rec print ~depth ppf t =
+    Place_map.iter
+      (fun (dbg, cl, _) v ->
+         match v with
+         | Closure t ->
+           Format.fprintf ppf "@[<h>%a Definition of %a%s@]@."
+             print_stars (depth + 1)
+             Closure_id.print cl
+             (Debuginfo.to_string dbg);
+           print ppf ~depth:(depth + 1) t;
+           if depth = 0 then Format.pp_print_newline ppf ()
+         | Call c ->
+           match c.decision with
+           | None ->
+             Misc.fatal_error "Inlining_report.print: missing call decision"
+           | Some decision ->
+             Format.pp_open_vbox ppf (depth + 2);
+             Format.fprintf ppf "@[<h>%a Application of %a%s@]@;@;@[%a@]"
+               print_stars (depth + 1)
+               Closure_id.print cl
+               (Debuginfo.to_string dbg)
+               Inlining_stats_types.Decision.summary decision;
+             Format.pp_close_box ppf ();
+             Format.pp_print_newline ppf ();
+             Format.pp_print_newline ppf ();
+             Inlining_stats_types.Decision.calculation ~depth:(depth + 1) ppf decision;
+             begin
+               match decision with
+               | Prevented _ -> ()
+               | Nonrecursive _ -> begin
+                   match c.inlined with
+                   | None -> ()
+                   | Some inlined ->
+                     print ppf ~depth:(depth + 1) inlined
+                 end
+               | Recursive _ -> begin
+                   match c.specialised with
+                   | None -> ()
+                   | Some specialised ->
+                     print ppf ~depth:(depth + 1) specialised
+                 end
+             end;
+             if depth = 0 then Format.pp_print_newline ppf ())
+      t
+
+  let print ppf t = print ~depth:0 ppf t
+
+end
+
 let really_save_then_forget_decisions ~output_prefix =
-  let out_channel = open_out (output_prefix ^ ".inlining") in
-  Closure_id.Tbl.iter (fun closure_id bucket ->
-      Printf.fprintf out_channel "%a\n" Closure_id.output closure_id;
-      let bucket =
-        let rebased_time = ref (-1) in
-        (* Rebase timestamps to start at zero within each bucket. *)
-        List.rev_map (fun (key, (closure_stack, decision)) ->
-            incr rebased_time;
-            key, (!rebased_time, closure_stack, decision))
-          bucket
-      in
-      let bucket = List.sort Line_number_then_time.compare_fst bucket in
-      List.iter (fun (key, (time, closure_stack, decision)) ->
-          let line = Line_number_then_time.line_number key in
-          Printf.fprintf out_channel "  %5d: (%5d) " line time;
-          Closure_stack.save closure_stack ~out_channel;
-          Printf.fprintf out_channel ": %s\n"
-            (Inlining_stats_types.Decision.to_string decision))
-        bucket;
-      Printf.fprintf out_channel "\n") decisions;
-  Printf.fprintf out_channel "# %s\n" vim_trailer;
+  let report = Inlining_report.build !log in
+  let out_channel = open_out (output_prefix ^ ".inlining.org") in
+  let ppf = Format.formatter_of_out_channel out_channel in
+  Inlining_report.print ppf report;
+  (*Format.fprintf ppf "@.# %s@." vim_trailer;*)
   close_out out_channel;
-  Closure_id.Tbl.clear decisions;
-  time := 0
+  log := []
 
 let save_then_forget_decisions ~output_prefix =
   if !Clflags.inlining_stats then begin

--- a/middle_end/inlining_stats.mli
+++ b/middle_end/inlining_stats.mli
@@ -22,14 +22,23 @@ module Closure_stack : sig
   val note_entering_closure
      : t
     -> closure_id:Closure_id.t
-    -> where:Inlining_stats_types.where_entering_closure
+    -> debuginfo:Debuginfo.t
     -> t
+
+  val note_entering_call
+    : t
+    -> closure_id:Closure_id.t
+    -> debuginfo:Debuginfo.t
+    -> t
+
+  val note_entering_inlined : t -> t
+  val note_entering_specialised : t -> closure_ids:Closure_id.Set.t -> t
+
 end
 
 val record_decision
    : Inlining_stats_types.Decision.t
   -> closure_stack:Closure_stack.t
-  -> debuginfo:Debuginfo.t
   -> unit
 
 val save_then_forget_decisions : output_prefix:string -> unit

--- a/middle_end/inlining_stats_types.ml
+++ b/middle_end/inlining_stats_types.ml
@@ -16,90 +16,211 @@
 
 module Wsb = Inlining_cost.Whether_sufficient_benefit
 
-module Tried_unrolling = struct
-  type t =
-    | Tried_unrolling of bool
+let print_stars ppf n =
+  let s = String.make n '*' in
+  Format.fprintf ppf "%s" s
 
-  let to_string = function
-    | Tried_unrolling true -> "tried unrolling"
-    | Tried_unrolling false -> "did not try unrolling"
-end
-
-module Copying_body = struct
-  type t =
-    | Unconditionally
-    | Decl_local_to_application
-    | Evaluated of Wsb.t
-    | Evaluated_unspecialized
-    | Stub
-
-  let to_string = function
-    | Unconditionally -> "unconditionally"
-    | Decl_local_to_application -> "decl local to application expression"
-    | Evaluated wsb -> Wsb.to_string wsb
-    | Evaluated_unspecialized -> "too large without specialized arguments"
-    | Stub -> "stub"
-end
+let print_calculation ~depth ~title ~subfunctions ppf wsb =
+  Format.pp_open_vbox ppf (depth + 2);
+  Format.fprintf ppf "@[<h>%a %s@]@;@;@[%a@]"
+    print_stars (depth + 1)
+    title
+    (Wsb.print_description ~subfunctions) wsb;
+  Format.pp_close_box ppf ();
+  Format.pp_print_newline ppf ();
+  Format.pp_print_newline ppf ()
 
 module Inlined = struct
-  type t =
-    | Copying_body of Copying_body.t
-    | Copying_body_with_subfunctions of Copying_body.t
-    | Unrolled of Wsb.t
-    | Copying_decl of Tried_unrolling.t * Wsb.t
+  type not_inlined_reason =
+    | Unspecialized
+    | Without_subfunctions of Wsb.t
+    | With_subfunctions of Wsb.t * Wsb.t
 
-  let to_string = function
-    | Copying_body cb ->
-      Printf.sprintf "copying body (%s)" (Copying_body.to_string cb)
-    | Copying_body_with_subfunctions cb ->
-      Printf.sprintf "copying body using subfunctions (%s)" (Copying_body.to_string cb)
-    | Unrolled wsb ->
-      Printf.sprintf "unrolled (%s)" (Wsb.to_string wsb)
-    | Copying_decl (tried, wsb) ->
-      Printf.sprintf "copying decl (%s, %s)"
-        (Tried_unrolling.to_string tried) (Wsb.to_string wsb)
+  let not_inlined_reason_summary ppf = function
+    | Unspecialized ->
+      Format.pp_print_text ppf
+        " because its parameters could not be specialised."
+    | Without_subfunctions _ ->
+      Format.pp_print_text ppf
+        " because the expected benefit did not \
+         outweigh the change in code size."
+    | With_subfunctions _ ->
+      Format.pp_print_text ppf
+        " because the expected benefit did not \
+         outweigh the change in code size."
+
+  let not_inlined_reason_calculation ~depth ppf = function
+    | Unspecialized -> ()
+    | Without_subfunctions wsb ->
+      print_calculation
+        ~depth ~title:"Inlining benefit calculation"
+        ~subfunctions:false ppf wsb
+    | With_subfunctions(_, wsb) ->
+      print_calculation
+        ~depth ~title:"Inlining benefit calculation"
+        ~subfunctions:true ppf wsb
+
+  type inlined_reason =
+    | Unconditionally
+    | Decl_local_to_application
+    | Stub
+    | Without_subfunctions of Wsb.t
+    | With_subfunctions of Wsb.t * Wsb.t
+
+  let inlined_reason_summary ppf = function
+    | Unconditionally ->
+      Format.pp_print_text ppf " because of an annotation."
+    | Decl_local_to_application ->
+      Format.pp_print_text ppf " because it was local to this application."
+    | Stub ->
+      Format.pp_print_text ppf " because it was a stub."
+    | Without_subfunctions _ ->
+      Format.pp_print_text ppf
+        " because the expected benefit outweighed the change in code size."
+    | With_subfunctions _ ->
+      Format.pp_print_text ppf
+        " because the expected benefit outweighed the change in code size."
+
+  let inlined_reason_calculation ~depth ppf = function
+    | Unconditionally -> ()
+    | Decl_local_to_application -> ()
+    | Stub -> ()
+    | Without_subfunctions wsb ->
+      print_calculation
+        ~depth ~title:"Inlining benefit calculation"
+        ~subfunctions:false ppf wsb
+    | With_subfunctions(_, wsb) ->
+      print_calculation
+        ~depth ~title:"Inlining benefit calculation"
+        ~subfunctions:true ppf wsb
+
+  type t =
+    | Not_inlined of not_inlined_reason
+    | Inlined of inlined_reason
+
+  let summary ppf = function
+    | Not_inlined r ->
+      Format.pp_print_text ppf "This function was not inlined";
+      not_inlined_reason_summary ppf r
+    | Inlined r ->
+      Format.pp_print_text ppf "This function was inlined";
+      inlined_reason_summary ppf r
+
+  let calculation ~depth ppf = function
+    | Not_inlined r -> not_inlined_reason_calculation ~depth ppf r
+    | Inlined r -> inlined_reason_calculation ~depth ppf r
+
 end
 
-module Decision = struct
+module Unrolled = struct
+  type t =
+    | Unrolling_not_tried
+    | Not_unrolled of Wsb.t
+    | Unrolled of Wsb.t
 
-  type level_exceeded =
-    | Level_exceeded of bool
+  let summary ppf = function
+    | Unrolling_not_tried ->
+      Format.pp_print_text ppf "This function was not eligible for unrolling."
+    | Not_unrolled _ ->
+      Format.pp_print_text ppf
+        "This function was not unrolled because the expected benefit \
+         did not outweigh the change in code size."
+    | Unrolled _ ->
+      Format.pp_print_text ppf
+        "This function was unrolled because the expected benefit \
+         outweighed the change in code size."
 
+  let calculation ~depth ppf = function
+    | Unrolling_not_tried -> ()
+    | Not_unrolled wsb ->
+      print_calculation
+        ~depth ~title:"Unrolling benefit calculation"
+        ~subfunctions:true ppf wsb
+    | Unrolled wsb ->
+      print_calculation
+        ~depth ~title:"Unrolling benefit calculation"
+        ~subfunctions:true ppf wsb
+
+end
+
+module Specialised = struct
+  type t =
+    | Specialising_not_tried
+    | Not_specialised of Wsb.t
+    | Specialised of Wsb.t
+
+  let summary ppf = function
+    | Specialising_not_tried ->
+      Format.pp_print_text ppf "This function was not eligible for specialising."
+    | Not_specialised _ ->
+      Format.pp_print_text ppf
+        "This function was not specialised because the expected benefit \
+         did not outweigh the change in code size."
+    | Specialised _ ->
+      Format.pp_print_text ppf
+        "This function was specialised because the expected benefit \
+         outweighed the change in code size."
+
+  let calculation ~depth ppf = function
+    | Specialising_not_tried -> ()
+    | Not_specialised wsb ->
+      print_calculation
+        ~depth ~title:"Specialising benefit calculation"
+        ~subfunctions:true ppf wsb
+    | Specialised wsb ->
+      print_calculation
+        ~depth ~title:"Specialising benefit calculation"
+        ~subfunctions:true ppf wsb
+
+end
+
+module Nonrecursive = struct
+  type t = Inlined.t
+end
+
+module Recursive = struct
+  type t = Unrolled.t * Specialised.t
+end
+
+module Prevented = struct
   type t =
     | Function_obviously_too_large of int
     | Function_prevented_from_inlining
-    | Inlined of Inlined.t
-    | Tried of Inlined.t
-    | Did_not_try_copying_decl of Tried_unrolling.t
-    | Can_inline_but_tried_nothing of level_exceeded
+    | Level_exceeded
+    | Classic_heuristic
 
-  let to_string = function
-    | Function_obviously_too_large threshold ->
-      Printf.sprintf "function obviously too large (threshold: %i)"
-        threshold
-    | Function_prevented_from_inlining -> "function prevented from inlining"
-    | Inlined inlined ->
-      Printf.sprintf "inlined (%s)" (Inlined.to_string inlined)
-    | Tried inlined ->
-      Printf.sprintf "tried but failed (%s)" (Inlined.to_string inlined)
-    | Did_not_try_copying_decl tried ->
-      Printf.sprintf "did not try copying decl (%s)"
-        (Tried_unrolling.to_string tried)
-    | Can_inline_but_tried_nothing (Level_exceeded b) ->
-        if b then
-          "can inline, but tried nothing, too deep into inlining"
-        else
-          "can inline, but tried nothing"
+  let summary ppf = function
+    | Function_obviously_too_large size ->
+      Format.pp_print_text ppf " because it was obviously too large ";
+      Format.fprintf ppf "(%i)." size
+    | Function_prevented_from_inlining -> ()
+    | Level_exceeded ->
+      Format.pp_print_text ppf " because the inlining depth was exceeded."
+    | Classic_heuristic ->
+      Format.pp_print_text ppf " by `-classic-heuristic'."
 end
 
-type where_entering_closure =
-  | Transform_set_of_closures_expression
-  | Inline_by_copying_function_body
-  | Inline_by_copying_function_declaration of Closure_id.Set.t
-  | Inlining_decision
+module Decision = struct
+  type t =
+    | Prevented of Prevented.t
+    | Nonrecursive of Nonrecursive.t
+    | Recursive of Recursive.t
 
-let char_of_where = function
-  | Transform_set_of_closures_expression -> 'T'
-  | Inline_by_copying_function_body -> 'B'
-  | Inline_by_copying_function_declaration _ -> 'D'
-  | Inlining_decision -> 'I'
+  let summary ppf = function
+    | Prevented p ->
+      Format.pp_print_text ppf
+        "This function was prevented from inlining or specialising";
+      Prevented.summary ppf p
+    | Nonrecursive i ->
+      Inlined.summary ppf i
+    | Recursive (u, s) ->
+      Format.fprintf ppf "@[<v>%a@,%a@]"
+        Unrolled.summary u Specialised.summary s
+
+  let calculation ~depth ppf = function
+    | Prevented _ -> ()
+    | Nonrecursive i -> Inlined.calculation ~depth ppf i
+    | Recursive (u, s) ->
+      Unrolled.calculation ~depth ppf u;
+      Specialised.calculation ~depth ppf s
+end

--- a/middle_end/inlining_stats_types.mli
+++ b/middle_end/inlining_stats_types.mli
@@ -16,54 +16,66 @@
 
 (* Types used for producing statistics about inlining. *)
 
-module Tried_unrolling : sig
-  type t =
-    | Tried_unrolling of bool
+module Inlined : sig
+  type not_inlined_reason =
+    | Unspecialized
+    | Without_subfunctions of
+        Inlining_cost.Whether_sufficient_benefit.t
+    | With_subfunctions of
+        Inlining_cost.Whether_sufficient_benefit.t
+        * Inlining_cost.Whether_sufficient_benefit.t
 
-  val to_string : t -> string
-end
-
-module Copying_body : sig
-  type t =
+  type inlined_reason =
     | Unconditionally
     | Decl_local_to_application
-    | Evaluated of Inlining_cost.Whether_sufficient_benefit.t
-    | Evaluated_unspecialized
     | Stub
+    | Without_subfunctions of Inlining_cost.Whether_sufficient_benefit.t
+    | With_subfunctions of
+        Inlining_cost.Whether_sufficient_benefit.t
+        * Inlining_cost.Whether_sufficient_benefit.t
 
-  val to_string : t -> string
-end
-
-module Inlined : sig
   type t =
-    | Copying_body of Copying_body.t
-    | Copying_body_with_subfunctions of Copying_body.t
-    | Unrolled of Inlining_cost.Whether_sufficient_benefit.t
-    | Copying_decl of
-        Tried_unrolling.t * Inlining_cost.Whether_sufficient_benefit.t
-
-  val to_string : t -> string
+    | Not_inlined of not_inlined_reason
+    | Inlined of inlined_reason
 end
 
-module Decision : sig
-  type level_exceeded =
-    | Level_exceeded of bool
+module Unrolled : sig
+  type t =
+    | Unrolling_not_tried
+    | Not_unrolled of Inlining_cost.Whether_sufficient_benefit.t
+    | Unrolled of Inlining_cost.Whether_sufficient_benefit.t
+end
 
+module Specialised : sig
+  type t =
+    | Specialising_not_tried
+    | Not_specialised of Inlining_cost.Whether_sufficient_benefit.t
+    | Specialised of Inlining_cost.Whether_sufficient_benefit.t
+end
+
+module Nonrecursive : sig
+  type t = Inlined.t
+end
+
+module Recursive : sig
+  type t = Unrolled.t * Specialised.t
+end
+
+module Prevented : sig
   type t =
     | Function_obviously_too_large of int
     | Function_prevented_from_inlining
-    | Inlined of Inlined.t
-    | Tried of Inlined.t
-    | Did_not_try_copying_decl of Tried_unrolling.t
-    | Can_inline_but_tried_nothing of level_exceeded
-
-  val to_string : t -> string
+    | Level_exceeded
+    | Classic_heuristic
 end
 
-type where_entering_closure =
-  | Transform_set_of_closures_expression
-  | Inline_by_copying_function_body
-  | Inline_by_copying_function_declaration of Closure_id.Set.t
-  | Inlining_decision
+module Decision : sig
 
-val char_of_where : where_entering_closure -> char
+  type t =
+    | Prevented of Prevented.t
+    | Nonrecursive of Nonrecursive.t
+    | Recursive of Recursive.t
+
+  val summary : Format.formatter -> t -> unit
+  val calculation : depth:int -> Format.formatter -> t -> unit
+end

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -164,10 +164,7 @@ let inline_by_copying_function_body ~env ~r ~function_decls ~lhs_of_application
       function_decls.Flambda.funs
       bindings_for_vars_bound_by_closure_and_params_to_args
   in
-  let env =
-    E.note_entering_closure env ~closure_id:closure_id_being_applied
-      ~where:Inline_by_copying_function_body
-  in
+  let env = E.note_entering_inlined env in
   simplify (E.activate_freshening env) r expr
 
 let inline_by_copying_function_declaration ~env ~r
@@ -326,7 +323,6 @@ let inline_by_copying_function_declaration ~env ~r
           List.map Closure_id.wrap
             (Variable.Set.elements (Variable.Map.keys function_decls.funs)))
       in
-      E.note_entering_closure env ~closure_id:closure_id_being_applied
-        ~where:(Inline_by_copying_function_declaration closure_ids)
+      E.note_entering_specialised env ~closure_ids
     in
     Some (simplify (E.activate_freshening env) r expr)

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -64,7 +64,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _impl s = with_impl := true; option_with_arg "-impl" s
   let _inline n = option_with_arg "-inline" n
   let _inline_toplevel n = option_with_arg "-inline-toplevel" n
-  let _inlining_stats = option "-inlining-stats"
+  let _inlining_stats = option "-inlining-report"
   let _dump_pass = option_with_arg "-dump-pass"
   let _max_inlining_depth n = option_with_arg "-max-inlining-depth" n
   let _rounds n = option_with_int "-rounds" n


### PR DESCRIPTION
Changes how inlining decisions are reported and switches output ordering and format (now org-mode). Also changes the option from `-inlining-stats` to `-inlining-report`.
