### PR TITLE
Augment_closures: lifting of Move_within_set_of_closures

### DIFF
--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -86,10 +86,11 @@ let implementation ppf sourcefile outputprefix ~backend =
     if not !Clflags.print_types then begin
       if Config.flambda then begin
         if !Clflags.o3 then begin
-          Clflags.simplify_rounds := 3;
+          Clflags.simplify_rounds := 4;
           Clflags.use_inlining_arguments_set ~round:0 Clflags.o1_arguments;
           Clflags.use_inlining_arguments_set ~round:1 Clflags.o2_arguments;
-          Clflags.use_inlining_arguments_set ~round:2 Clflags.o3_arguments
+          Clflags.use_inlining_arguments_set ~round:2 Clflags.o3_arguments;
+          Clflags.use_inlining_arguments_set ~round:3 Clflags.o3_arguments
         end
         else if !Clflags.o2 then begin
           Clflags.simplify_rounds := 2;

--- a/middle_end/augment_closures.ml
+++ b/middle_end/augment_closures.ml
@@ -14,24 +14,39 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(* CR mshinwell: Consider renaming to "Lift_projections".  Add a comment
+   that explains how this works in conjunction with Unbox_closures, namely
+   that this pass lifts and names expressions such that the function in
+   question may be specialized over them. *)
+
 module A = Simple_value_approx
 module E = Inline_and_simplify_aux.Env
 
-type closures_in_free_vars =
-  {
-    new_var : Variable.t;
-    closure_id : Closure_id.t;
-    outside_var : Variable.t;
-  }
+(* CR-soon mshinwell: Refactor this module to use something like
+   [Flambda_iterators.projection] throughout. *)
 
-type block_in_free_vars =
-  {
-    new_var : Variable.t;
-    outside_var : Variable.t;
-  }
+type var_within_closures_in_free_vars = {
+  new_var : Variable.t;
+  closure_id : Closure_id.t;
+  outside_var : Variable.t;
+}
+
+type closures_in_free_vars = {
+  new_var : Variable.t;
+  start_from : Closure_id.t;
+  outside_var : Variable.t;
+}
+
+type block_in_free_vars = {
+  new_var : Variable.t;
+  outside_var : Variable.t;
+}
+
+module Var_within_closure_field =
+  Identifiable.Make (Identifiable.Pair (Variable) (Var_within_closure))
 
 module Closure_field =
-  Identifiable.Make (Identifiable.Pair (Variable) (Var_within_closure))
+  Identifiable.Make (Identifiable.Pair (Variable) (Closure_id))
 
 module Block_field =
   Identifiable.Make (Identifiable.Pair (Variable) (Numbers.Int))
@@ -39,29 +54,50 @@ module Block_field =
 let freshened_var env v =
   Freshening.apply_variable (E.freshening env) v
 
-let closures_in_variables ~env map acc =
-  Variable.Map.fold (fun inside_var outside_var acc ->
+let closures_in_variables ~env map acc
+      : var_within_closures_in_free_vars Var_within_closure_field.Map.t
+          * closures_in_free_vars Closure_field.Map.t
+          * block_in_free_vars Block_field.Map.t =
+  Variable.Map.fold (fun inside_var outside_var
+        (var_within_closure_acc, closure_acc, block_acc) ->
       let approx = E.find_exn env (freshened_var env outside_var) in
       match A.check_approx_for_closure approx with
       | Ok (value_closure, _approx_var, _approx_symbol,
             value_set_of_closures) ->
-        Var_within_closure.Map.fold (fun bound_var _ (closure_acc, block_acc) ->
-            let new_var =
-              Variable.create (Var_within_closure.unique_name bound_var)
-            in
-            let closure_acc =
-              Closure_field.Map.add (inside_var, bound_var)
-                { new_var; closure_id = value_closure.closure_id; outside_var }
-                closure_acc
-            in
-            closure_acc, block_acc)
-          value_set_of_closures.bound_vars acc
+        let var_within_closure_acc =
+          Var_within_closure.Map.fold
+            (fun bound_var _ acc ->
+              let new_var =
+                Variable.create (Var_within_closure.unique_name bound_var)
+              in
+              Var_within_closure_field.Map.add (inside_var, bound_var)
+                { new_var; closure_id = value_closure.closure_id; outside_var;
+                }
+                acc)
+            value_set_of_closures.bound_vars var_within_closure_acc
+        in
+        let closure_acc =
+          Variable.Map.fold (fun fun_var _ acc ->
+              let new_var = Variable.rename fun_var in
+              let start_from = value_closure.closure_id in
+              let move_to = Closure_id.wrap fun_var in
+              (* For the moment represent all projections of closures as
+                 moves from the original closure ID. *)
+              (* CR-someday mshinwell: consider using the set-of-closures-var
+                 ("_approx_var" above) instead.  See handling in
+                 inline_and_simplify.ml, e.g. simplify_project_var: need
+                 to check the variable is in scope. *)
+              Closure_field.Map.add (inside_var, move_to)
+                ({ new_var; start_from; outside_var; } : closures_in_free_vars)
+                acc)
+            value_set_of_closures.function_decls.funs closure_acc
+        in
+        var_within_closure_acc, closure_acc, block_acc
       | Wrong ->
         match A.check_approx_for_block approx with
         | Wrong ->
           acc  (* Ignore free_vars that aren't closures or blocks. *)
         | Ok (_tag, fields) ->
-          let closure_acc, block_acc = acc in
           let block_acc = ref block_acc in
           Array.iteri (fun i approx ->
               (* CR-soon pchambart: should we restrict only to cases
@@ -76,15 +112,15 @@ let closures_in_variables ~env map acc =
               | Some v when E.mem env v ->
                 let new_var =
                   Variable.create
-                    (Variable.unique_name inside_var ^ "_field_" ^ string_of_int i)
+                    (Variable.unique_name inside_var ^ "_field_"
+                      ^ string_of_int i)
                 in
-                block_acc :=
-                  Block_field.Map.add (inside_var, i) { new_var; outside_var } !block_acc
-              | Some _ ->
-                ()
+                block_acc := Block_field.Map.add (inside_var, i)
+                  { new_var; outside_var } !block_acc
+              | Some _ -> ()
               | _ -> ())
             fields;
-          closure_acc, !block_acc)
+          var_within_closure_acc, closure_acc, !block_acc)
     map
     acc
 
@@ -94,50 +130,64 @@ let rewrite_set_of_closures
   let elts_in_free_vars =
     closures_in_variables ~env
       set_of_closures.free_vars
-      (Closure_field.Map.empty, Block_field.Map.empty)
+      (Var_within_closure_field.Map.empty, Closure_field.Map.empty,
+        Block_field.Map.empty)
   in
   let elts_in_free_vars_and_specialised_args =
     closures_in_variables ~env
       set_of_closures.specialised_args
       elts_in_free_vars
   in
-  let closures_in_free_vars,
+  let var_within_closures_in_free_vars,
+      closures_in_free_vars,
       block_in_free_vars =
     elts_in_free_vars_and_specialised_args
   in
-  if Closure_field.Map.is_empty closures_in_free_vars
+  if Var_within_closure_field.Map.is_empty var_within_closures_in_free_vars
+    && Closure_field.Map.is_empty closures_in_free_vars
     && Block_field.Map.is_empty block_in_free_vars
   then
     set_of_closures, Variable.Map.empty, Variable.Map.empty
   else
     let used_new_vars = Variable.Tbl.create 42 in
-    let rewrite_function_decl
-        (function_decl:Flambda.function_declaration) =
+    let rewrite_function_decl (function_decl : Flambda.function_declaration) =
       let body =
-        Flambda_iterators.map_toplevel_project_var_to_expr_opt
-          ~f:(fun project_var ->
-            match
-              Closure_field.Map.find
-                (project_var.closure, project_var.var)
-                closures_in_free_vars
-            with
-            | exception Not_found ->
+        Flambda_iterators.map_toplevel_projections_to_expr_opt
+          ~f:(fun (projection : Flambda_iterators.projection) ->
+            match projection with
+            | Project_var { closure; var; closure_id = _; } ->
+              begin match
+                Var_within_closure_field.Map.find (closure, var)
+                  var_within_closures_in_free_vars
+              with
+              | exception Not_found -> None
+              | { new_var; _ } ->
+                Variable.Tbl.add used_new_vars new_var ();
+                Some (Flambda.Var new_var)
+              end
+            | Project_closure _project_closure ->
+              (* CR-soon mshinwell: implement this *)
               None
-            | { new_var } ->
-              Variable.Tbl.add used_new_vars new_var ();
-              Some (Flambda.Var new_var))
+            | Move_within_set_of_closures
+                { closure; move_to; start_from = _; } ->
+              begin match
+                Closure_field.Map.find (closure, move_to) closures_in_free_vars
+              with
+              | exception Not_found -> None
+              | { new_var; _ } ->
+                Variable.Tbl.add used_new_vars new_var ();
+                Some (Flambda.Var new_var)
+              end
+            | Field (i, v) ->
+              if not (Block_field.Map.mem (v, i) block_in_free_vars) then
+                None
+              else
+                let { new_var; _ } =
+                  Block_field.Map.find (v, i) block_in_free_vars
+                in
+                Variable.Tbl.add used_new_vars new_var ();
+                Some (Flambda.Var new_var))
           function_decl.body
-      in
-      let body =
-        Flambda_iterators.map_toplevel_named (function
-            | (Prim (Pfield i, [v], _)) when
-                Block_field.Map.mem (v, i) block_in_free_vars ->
-              let { new_var } = Block_field.Map.find (v, i) block_in_free_vars in
-              Variable.Tbl.add used_new_vars new_var ();
-              Expr (Var new_var)
-            | named ->
-              named)
-          body
       in
       Flambda.create_function_declaration
         ~body
@@ -157,21 +207,46 @@ let rewrite_set_of_closures
         set_of_closures.function_decls
     in
     let free_vars, add_closures =
-      Closure_field.Map.fold
-        (fun (_var, field) { new_var; closure_id; outside_var } (free_vars, add_closures) ->
-           let intermediate_var =
-             Variable.rename new_var
-           in
-           if Variable.Tbl.mem used_new_vars new_var then
-             Variable.Map.add new_var intermediate_var free_vars,
-             Variable.Map.add intermediate_var
-               (Flambda.Project_var { Flambda.closure = outside_var; closure_id; var = field })
-               add_closures
-           else
-             free_vars, add_closures)
-        closures_in_free_vars
+      Var_within_closure_field.Map.fold
+        (fun (_var, field) { new_var; closure_id; outside_var; }
+              (free_vars, add_closures) ->
+          let intermediate_var = Variable.rename new_var in
+          if Variable.Tbl.mem used_new_vars new_var then
+            let defining_expr : Flambda.named =
+              Project_var {
+                closure = outside_var;
+                closure_id;
+                var = field;
+              }
+            in
+            Variable.Map.add new_var intermediate_var free_vars,
+              Variable.Map.add intermediate_var defining_expr add_closures
+          else
+            free_vars, add_closures)
+        var_within_closures_in_free_vars
         (set_of_closures.free_vars,
          Variable.Map.empty)
+    in
+    let free_vars, add_closures =
+      Closure_field.Map.fold
+        (fun (_var, move_to)
+              ({ new_var; start_from; outside_var; } : closures_in_free_vars)
+              (free_vars, add_closures) ->
+          let intermediate_var = Variable.rename new_var in
+          if Variable.Tbl.mem used_new_vars new_var then
+            let defining_expr : Flambda.named =
+              Move_within_set_of_closures {
+                closure = outside_var;
+                start_from;
+                move_to;
+              }
+            in
+            Variable.Map.add new_var intermediate_var free_vars,
+              Variable.Map.add intermediate_var defining_expr add_closures
+          else
+            free_vars, add_closures)
+        closures_in_free_vars
+        (free_vars, add_closures)
     in
     let free_vars, add_blocks =
       Block_field.Map.fold
@@ -199,14 +274,20 @@ let rewrite_set_of_closures
 let run ~env ~(set_of_closures:Flambda.set_of_closures) : Flambda.t option =
   if !Clflags.classic_inlining then None
   else
+    let dump = false in
+    if dump then begin
+      Format.eprintf "Before Augment_closures:@ %a@.@."
+        Flambda.print_set_of_closures set_of_closures;
+    end;
     let set_of_closures, add_closures, add_blocks =
       rewrite_set_of_closures
         ~env ~set_of_closures
     in
     if Variable.Map.is_empty add_closures &&
-       Variable.Map.is_empty add_blocks then
+       Variable.Map.is_empty add_blocks then begin
+      if dump then Format.eprintf "Augment_closures did nothing.\n%!";
       None
-    else
+    end else begin
       let expr =
         Variable.Map.fold Flambda.create_let
           add_closures
@@ -217,4 +298,9 @@ let run ~env ~(set_of_closures:Flambda.set_of_closures) : Flambda.t option =
         Variable.Map.fold Flambda.create_let
           add_blocks expr
       in
+      if dump then begin
+        Format.eprintf "After Augment_closures:@ %a@.@."
+          Flambda.print expr
+      end;
       Some expr
+    end

--- a/middle_end/flambda_iterators.mli
+++ b/middle_end/flambda_iterators.mli
@@ -195,9 +195,15 @@ val map_project_var_to_expr_opt
   -> f:(Flambda.project_var -> Flambda.t option)
   -> Flambda.t
 
-val map_toplevel_project_var_to_expr_opt
+type projection =
+  | Project_var of Flambda.project_var
+  | Project_closure of Flambda.project_closure
+  | Move_within_set_of_closures of Flambda.move_within_set_of_closures
+  | Field of int * Variable.t
+
+val map_toplevel_projections_to_expr_opt
    : Flambda.t
-  -> f:(Flambda.project_var -> Flambda.t option)
+  -> f:(projection -> Flambda.t option)
   -> Flambda.t
 
 val map_project_var_to_named_opt

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -252,6 +252,12 @@ let simplify_project_closure env r ~(project_closure : Flambda.project_closure)
     match reference_recursive_function_directly env closure_id with
     | Some (flam, approx) -> flam, ret r approx
     | None ->
+      let set_of_closures_var =
+        match set_of_closures_var with
+        | Some set_of_closures_var' when E.mem env set_of_closures_var' ->
+          set_of_closures_var
+        | Some _ | None -> None
+      in
       let approx =
         A.value_closure ?set_of_closures_var value_set_of_closures
           closure_id


### PR DESCRIPTION
Required for example to compile Async_unix.Raw_scheduler.sync_changed_fds_to_file_descr_watcher with proper unboxing of closures.

This works just for this source file, but when doing the whole tree up to that point it produces:

> > Fatal error: [functions] does not map set of closures ID Async_kernel__Monitor0._2189.

I've discovered that Async_kernel__Monitor.2189 (not Monitor0) was a set of closures ID referenced from a Project_closure created by Inline_and_simplify when simplifying a Move_set_of_closures.  I don't yet know where the Monitor0 set of closures ID comes from.
