### PR TITLE
More accurate benefit

### DIFF
--- a/middle_end/inlining_stats.ml
+++ b/middle_end/inlining_stats.ml
@@ -248,7 +248,7 @@ module Inlining_report = struct
              begin
                match decision with
                | Prevented _ -> ()
-               | Nonrecursive _ -> begin
+               | Nonrecursive _ | Recursive(Unrolled _, _)-> begin
                    match c.inlined with
                    | None -> ()
                    | Some inlined ->

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -154,13 +154,19 @@ let inline_by_copying_function_body ~env ~r ~function_decls ~lhs_of_application
   *)
   let expr =
     Variable.Map.fold (fun another_closure_in_the_same_set _ expr ->
+      let used =
+        Variable.Set.mem another_closure_in_the_same_set
+           function_decl.free_variables
+      in
+      if used then
         Flambda.create_let another_closure_in_the_same_set
           (Move_within_set_of_closures {
             closure = lhs_of_application;
             start_from = closure_id_being_applied;
             move_to = Closure_id.wrap another_closure_in_the_same_set;
           })
-          expr)
+          expr
+      else expr)
       function_decls.Flambda.funs
       bindings_for_vars_bound_by_closure_and_params_to_args
   in


### PR DESCRIPTION
Only create bindings for other functions in the set of closures
if those closures are actually used. This avoids giving spurious
benefit when those unnecessary Move_within_closures are removed.

Also fixes a bug with the inlining report for unrolled functions.
