### PR TITLE
tests/asmcomp: simplify checking for flambda; debug compilation

### DIFF
--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -45,7 +45,7 @@ lexcmm.ml: lexcmm.mll
 	@$(OCAMLLEX) -q lexcmm.mll
 
 MLCASES=optargs staticalloc bind_tuples is_static
-ARGS_is_static=is_in_static_data.o
+ARGS_is_static=is_in_static_data.c
 
 CASES=fib tak quicksort quicksort2 soli \
       arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak
@@ -63,16 +63,12 @@ ARGS_tagged-quicksort=-DSORT -DFUN=quicksort main.c
 ARGS_tagged-tak=-DUNIT_INT -DFUN=takmain main.c
 
 one_ml:
-	@$(OCAMLOPT) -o $(NAME).exe $(NAME).ml && \
-	./$(NAME).exe `$(OCAMLOPT) -config` \
-	&& echo " => passed" || echo " => failed"
+	@$(OCAMLOPT) $(ARGS_$(NAME)) -o $(NAME).exe $(NAME).ml && \
+	./$(NAME).exe $(FLAMBDA) && echo " => passed" || echo " => failed"
 
 one:
 	@$(call CC,$(NAME).out $(ARGS_$(NAME)) $(NAME).$(O) $(ARCH).$(O)) \
 	&& echo " => passed" || echo " => failed"
-
-is_in_static_data.o: is_in_static_data.c
-	@$(OCAMLOPT) -c is_in_static_data.c
 
 clean: defaultclean
 	@rm -f ./codegen *.out *.$(O) *.exe

--- a/testsuite/tests/asmcomp/is_static.ml
+++ b/testsuite/tests/asmcomp/is_static.ml
@@ -1,5 +1,5 @@
 external is_in_static_data : 'a -> bool = "caml_is_in_static_data"
-let flambda = List.exists ((=) "flambda: true") (Array.to_list Sys.argv)
+let flambda = bool_of_string Sys.argv.(1)
 let is_in_static_data_flambda x =
   not flambda || is_in_static_data x
 


### PR DESCRIPTION
Note that the test fails on my machine, saying that the calls at lines 26 and 122 cannot be inlined (warning 55).
