### PR TITLE
Fix some tests

### DIFF
--- a/testsuite/tests/basic-more/sequential_and_or.ml
+++ b/testsuite/tests/basic-more/sequential_and_or.ml
@@ -4,11 +4,7 @@
 (*                                                                     *)
 (*                      Pierre Chambart, OCamlPro                      *)
 (*                                                                     *)
-<<<<<<< HEAD
-(*  Copyright 2015 Institut National de Recherche en Informatique et   *)
-=======
 (*  Copyright 2016 Institut National de Recherche en Informatique et   *)
->>>>>>> ocaml/trunk
 (*  en Automatique.  All rights reserved.  This file is distributed    *)
 (*  under the terms of the Q Public License version 1.0.               *)
 (*                                                                     *)

--- a/testsuite/tests/typing-extension-constructor/test.ml
+++ b/testsuite/tests/typing-extension-constructor/test.ml
@@ -16,6 +16,10 @@ type t += A;;
 [%extension_constructor A];;
 ([%extension_constructor A] : extension_constructor);;
 
-type extension_constructor = int;;
+module M = struct
+  type extension_constructor = int
+end;;
+
+open M;;
 
 ([%extension_constructor A] : extension_constructor);;

--- a/testsuite/tests/typing-extension-constructor/test.ml.reference
+++ b/testsuite/tests/typing-extension-constructor/test.ml.reference
@@ -3,11 +3,10 @@
 # type t += A
 #   - : extension_constructor = <abstr>
 # - : extension_constructor = <abstr>
-#   type extension_constructor = int
-#   Characters 2-28:
+#       module M : sig type extension_constructor = int end
+#   #   Characters 2-28:
   ([%extension_constructor A] : extension_constructor);;
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type extension_constructor/16
-       but an expression was expected of type
-         extension_constructor/1210 = int
+Error: This expression has type extension_constructor
+       but an expression was expected of type M.extension_constructor = int
 # 


### PR DESCRIPTION
This fixes a few of the tests that are failing on the flambda branch.

I think the other failing tests indicate genuine regressions in flambda:
- Backtraces are missing locations for `Invalid_argument("index out of bounds")` from `Array.get`.
- The optional argument optimisation is not applying correctly to recursive uses of functions with optional arguments.
- Backtraces are missing frames for `@@`.
- Recursive values with float arrays can execute side-effects in different order from current ocamlopt.
- There is something wrong related to custom finalisers (pr3612)
- The warning numbers have been rearranged
- Warning 55 (unused `[@inline]` attribute) has much less helpful text with flambda.
