### PR TITLE
Mark opt arg wrappers of recursive functions as stubs

### DIFF
--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -63,6 +63,7 @@ let add_default_argument_wrappers lam =
                (function
                  | (id, Lambda.Lfunction {kind; params; body; attr}) ->
                    Simplif.split_default_wrapper id kind params body attr
+                     ~create_wrapper_body:stubify
                  | _ -> assert false)
                defs)
         in


### PR DESCRIPTION
This marks the optional argument wrappers as stubs even when the original function is recursive. Fixes the asmcomp/optargs test.
